### PR TITLE
Implement harmonypy component & make changes to concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEW FUNCTIONALITY
 
+* `integrate/harmonypy`: a python implementation of the harmony integration.
+
 * `workflows/integration/multiomics`: implement pipeline for processing multiple multiomics samples.
 
 * `transform/scaling`: Scale data to unit variance and zero mean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * `transform/scaling`: Scale data to unit variance and zero mean.
 
+* `integrate/harmony`: Added R based Harmony component.
+
 ## MAJOR CHANGES
 
 * Multiple components: update to anndata 0.8 with mudata 0.2.0. This means that the format of the .h5mu files have changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NEW FUNCTIONALITY
 
-* `integrate/harmonypy`: a python implementation of the harmony integration.
-
 * `workflows/integration/multiomics`: implement pipeline for processing multiple multiomics samples.
 
 * `transform/scaling`: Scale data to unit variance and zero mean.
 
-* `integrate/harmony`: Added R based Harmony component.
+* `integrate/harmony`: Added a component for running a Harmony integration analysis (R-based).
+
+* `integrate/harmonypy`: Added a component for running a Harmony integration analysis (Python-based).
 
 ## MAJOR CHANGES
 

--- a/src/integrate/concat/config.vsh.yaml
+++ b/src/integrate/concat/config.vsh.yaml
@@ -16,19 +16,23 @@ functionality:
       multiple_sep: ','
       description: Paths to the different samples to be concatenated.
       required: true
-      default: sample_paths
-    - name: "--output"
-      alternatives: ["-o"]
-      type: file
-      direction: output
-      default: "output.h5mu"
+      example: sample_paths
     - name: "--sample_names"
       type: string
       multiple: true
       multiple_sep: ','
-      description: Names of the different samples that have to be concatenated.
+      description: Names of the different samples that have to be concatenated. Must be of same length as `--input`.
       required: true
-      default: sample_names
+      example: sample_names
+    - name: "--output"
+      alternatives: ["-o"]
+      type: file
+      direction: output
+      example: "output.h5mu"
+    - name: "--obs_sample_name"
+      type: string
+      description: Name of the .obs key under which to add the sample names.
+      default: "sample_id"
     - name: "--compression"
       type: string
       description: The compression format to be used on the final h5mu object.

--- a/src/integrate/concat/script.py
+++ b/src/integrate/concat/script.py
@@ -26,7 +26,7 @@ logFormatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
 console_handler.setFormatter(logFormatter)
 logger.addHandler(console_handler)
 
-def add_sample_names(sample_ids: tuple[str], samples: list[mu.MuData], obs_key_sample_name: str) -> None:
+def add_sample_names(sample_ids: tuple[str], samples: Iterable[mu.MuData], obs_key_sample_name: str) -> None:
     """
     Add sample names to the observations for each sample.
     """
@@ -39,7 +39,7 @@ def add_sample_names(sample_ids: tuple[str], samples: list[mu.MuData], obs_key_s
         sample.update()
 
 
-def make_observation_keys_unique(sample_ids: tuple[str], samples: list[mu.MuData]) -> None:
+def make_observation_keys_unique(sample_ids: tuple[str], samples: Iterable[mu.MuData]) -> None:
     """
     Make the observation keys unique across all samples. At input,
     the observation keys are unique within a sample. By adding the sample name
@@ -61,7 +61,7 @@ def make_observation_keys_unique_per_mod(sample_id: str, sample: mu.MuData) -> N
         mod.obs_names = f"{sample_id}_" + mod.obs_names
 
 
-def group_modalities(samples: list[anndata.AnnData]) -> dict[str, anndata.AnnData]:
+def group_modalities(samples: Iterable[anndata.AnnData]) -> dict[str, anndata.AnnData]:
     """
     Split up the modalities of all samples and group them per modality.
     """
@@ -77,7 +77,7 @@ def group_modalities(samples: list[anndata.AnnData]) -> dict[str, anndata.AnnDat
     return mods
 
 
-def concat_columns(vars_list: list[pd.DataFrame]) -> pd.DataFrame:
+def concat_columns(vars_list: Iterable[pd.DataFrame]) -> pd.DataFrame:
     """
     Combine dataframes by joining matching columns into a comma-separated list
     containing unique, non-na values.
@@ -186,7 +186,7 @@ def set_conflicts(concatenated_data: mu.MuData,
             getattr(mod, conflict_matrix_name)[conflict_name] = conflict_data.sort_index()
     return concatenated_data
 
-def concatenate_modalities(sample_ids: tuple[str], modalities: dict[str, list[anndata.AnnData]],
+def concatenate_modalities(sample_ids: tuple[str], modalities: dict[str, Iterable[anndata.AnnData]],
                            other_axis_mode: str) -> mu.MuData:
     """
     Join the modalities together into a single multimodal sample.

--- a/src/integrate/concat/script.py
+++ b/src/integrate/concat/script.py
@@ -34,7 +34,7 @@ def add_sample_names(sample_ids: tuple[str], samples: Iterable[mu.MuData], obs_k
         if obs_key_sample_name in sample.obs_keys():
             logger.info(f'Column .obs["{obs_key_sample_name}"] already exists in sample "{sample_id}". Overriding the value for this column.')
             samples.obs = sample.obs.drop(obs_key_sample_name, axis=1)
-        for _, modality in sample.mod.items():
+        for modality in sample.mod.values():
             modality.obs[obs_key_sample_name] = sample_id
         sample.update()
 

--- a/src/integrate/concat/script.py
+++ b/src/integrate/concat/script.py
@@ -34,8 +34,10 @@ def add_sample_names(sample_ids: tuple[str], samples: list[mu.MuData]) -> None:
     for (sample_id, sample) in zip(sample_ids, samples):
         if "batch" in sample.obs_keys():
             samples.obs = sample.obs.drop("batch", axis=1)
-        sample.obs["batch"] = sample_id
+        for _, modality in sample.mod.items():
+            modality.obs["batch"] = sample_id
         sample.batch = sample_id
+        sample.update()
 
 
 def make_observation_keys_unique(samples: list[mu.MuData]) -> None:

--- a/src/integrate/concat/script.py
+++ b/src/integrate/concat/script.py
@@ -57,7 +57,7 @@ def make_observation_keys_unique_per_mod(sample_id: str, sample: mu.MuData) -> N
     Updating MuData.obs_names is not allowed (it is read-only).
     So the observation keys for each modality has to be updated manually.
     """
-    for _, mod in sample.mod.items():
+    for mod in sample.mod.values():
         mod.obs_names = f"{sample_id}_" + mod.obs_names
 
 

--- a/src/integrate/harmony/config.vsh.yaml
+++ b/src/integrate/harmony/config.vsh.yaml
@@ -1,16 +1,15 @@
 functionality:
-  name: harmonypy
+  name: harmony
   namespace: "integrate"
-  version: "dev"
-  description: "Performs Harmony integration based as described in https://github.com/immunogenomics/harmony.
-                Based on an implementation in python from https://github.com/slowkow/harmonypy"
+  description: "Performs Harmony integration based as described in https://github.com/immunogenomics/harmony."
   authors:
-    - name: Dries Schaumont
-      email: dries.schaumont@its.jnj.com
-      roles: [ maintainer ]
+    - name: Dries De Maeyer
+      email: ddemaeyer@gmail.com
+      roles: [ author ]
+      props: { account: ddemaey1 }
     - name: Robrecht Cannoodt
       email: rcannood@gmail.com
-      roles: [ contributor ]
+      roles: [ maintainer, author ]
       props: { github: rcannood, orcid: "0000-0003-3641-729X" }
   arguments:
     - name: "--input"
@@ -51,22 +50,26 @@ functionality:
       example: ["batch", "sample"]
       multiple: true
   resources:
-    - type: python_script
-      path: script.py
+    - type: r_script
+      path: script.R
+
   test_resources:
     - type: python_script
-      path: test.py
+      path: ../harmonypy/test.py
     - path: ../../../resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu
 platforms:
   - type: docker
-    image: python:3.10
+    image: ghcr.io/data-intuitive/randpy:r4.0_py3.10
     setup:
       - type: python
         packages:
           - mudata~=0.2.0
           - anndata~=0.8.0
-          - harmonypy~=0.0.6
-          - scanpy
+      - type: r
+        cran: 
+          - harmony
+          - anndata
+          - reticulate
   - type: nextflow
     variant: vdsl3
     directives:

--- a/src/integrate/harmony/script.R
+++ b/src/integrate/harmony/script.R
@@ -1,0 +1,37 @@
+library(reticulate)
+library(harmony)
+library(anndata)
+
+mudata <- reticulate::import("mudata")
+
+### VIASH START
+par <- list(
+  input = "resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu",
+  output = "foo.h5mu",
+  modality = "rna",
+  obsm_input = "X_pca",
+  obsm_output = "X_pca_integrated",
+  theta = 2,
+  obs_covariates = c("leiden")
+)
+### VIASH END
+
+data <- mudata$read_h5mu(par$input)
+rna_data <- data$mod[["rna"]]
+
+## Run Harmony
+pca_in <- rna_data$obsm[[par$obsm_input]]
+meta_data <- rna_data$obs
+harmony_embedding <- HarmonyMatrix(
+  data_mat = pca_in,
+  meta_data = meta_data,
+  vars_use = par$obs_covariates,
+  theta = par$theta,
+  do_pca = FALSE
+)
+
+## Add Harmony embeddings to Anndata
+rna_data$obsm[[par$obsm_output]] <- harmony_embedding
+
+## Save as H5AD
+data$write(par$output)

--- a/src/integrate/harmonypy/config.vsh.yaml
+++ b/src/integrate/harmonypy/config.vsh.yaml
@@ -1,0 +1,70 @@
+functionality:
+  name: harmonypy
+  namespace: "integrate"
+  version: "dev"
+  description: "Performs Harmony integration based as described in https://github.com/immunogenomics/harmony.
+                Based on an implementation in python from https://github.com/slowkow/harmonypy"
+  authors:
+    - name: Dries Schaumont
+      email: dries.schaumont@its.jnj.com
+      roles: [ maintainer ]
+  arguments:
+    - name: "--input"
+      alternatives: ["-i"]
+      type: file
+      description: Input h5mu file
+      direction: input
+      required: true
+    - name: "--output"
+      alternatives: ["-o"]
+      type: file
+      description: Output h5mu file.
+      direction: output
+      required: true
+    - name: "--modality"
+      type: string
+      multiple: true
+      default: "rna"
+      required: false
+    - name: "--pca_key"
+      type: string
+      default: "X_pca"
+      required: false
+      description: The field in the obs object that defined the input PCA embedding.
+    - name: "--output_key_suffix"
+      type: string
+      default: "harmonypy"
+      required: false
+      description: "Suffix for the key in .obsm where the results will be stored.
+                    The resulting key will be a comination of the pca key and the output key suffix."
+    - name: "--theta"
+      description: Theta value to perform correction on.
+      type: double
+      default: 0
+      multiple: true
+    - name: "--sample_key"
+      type: string
+      description: The field in the obs object that defines batches to perform correction to.
+      default: "batch"
+      multiple: true
+  resources:
+    - type: python_script
+      path: ./script.py
+  test_resources:
+    - type: python_script
+      path: test.py
+    - path: ../../../resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu
+platforms:
+  - type: docker
+    image: python:3.10
+    setup:
+      - type: python
+        packages:
+          - mudata~=0.2.0
+          - anndata~=0.8.0
+          - harmonypy~=0.0.6
+          - scanpy
+  - type: nextflow
+    variant: vdsl3
+    directives:
+      label: highmem

--- a/src/integrate/harmonypy/script.py
+++ b/src/integrate/harmonypy/script.py
@@ -1,0 +1,30 @@
+import mudata
+from harmonypy import run_harmony
+
+
+### VIASH START
+par = {
+    "input": "resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu",
+    "output": "foo.h5mu",
+    "compression": "gzip",
+    "modality": ["rna"],
+    "pca_key": "X_pca",
+    "output_key_suffix": "harmony",
+    "theta": 0,
+    "sample_key": "batch",
+}
+### VIASH END
+
+
+def main():
+    mdata = mudata.read(par["input"].strip())
+    for mod_name in par['modality']:
+        mod = mdata.mod[mod_name]
+        pca_embedding = mod.obsm[par['pca_key']]
+        metadata = mod.obs
+        ho = run_harmony(pca_embedding, metadata, par['sample_key'], theta=par['theta'])
+        mod.obsm[f'{par["pca_key"]}_{par["output_key_suffix"]}'] = ho.Z_corr.T
+    mdata.write_h5mu(par['output'].strip())
+
+if __name__ == "__main__":
+    main()

--- a/src/integrate/harmonypy/script.py
+++ b/src/integrate/harmonypy/script.py
@@ -8,10 +8,10 @@ par = {
     "output": "foo.h5mu",
     "compression": "gzip",
     "modality": ["rna"],
-    "pca_key": "X_pca",
-    "output_key_suffix": "harmony",
-    "theta": 0,
-    "sample_key": "batch",
+    "obsm_input": "X_pca",
+    "obsm_output": "X_pca_harmonypy",
+    "theta": 2,
+    "obs_covariates": ["batch"],
 }
 ### VIASH END
 
@@ -20,10 +20,10 @@ def main():
     mdata = mudata.read(par["input"].strip())
     for mod_name in par['modality']:
         mod = mdata.mod[mod_name]
-        pca_embedding = mod.obsm[par['pca_key']]
+        pca_embedding = mod.obsm[par['obsm_input']]
         metadata = mod.obs
-        ho = run_harmony(pca_embedding, metadata, par['sample_key'], theta=par['theta'])
-        mod.obsm[f'{par["pca_key"]}_{par["output_key_suffix"]}'] = ho.Z_corr.T
+        ho = run_harmony(pca_embedding, metadata, par['obs_covariates'], theta=par['theta'])
+        mod.obsm[par["obsm_output"]] = ho.Z_corr.T
     mdata.write_h5mu(par['output'].strip())
 
 if __name__ == "__main__":

--- a/src/integrate/harmonypy/test.py
+++ b/src/integrate/harmonypy/test.py
@@ -1,0 +1,52 @@
+import unittest
+import subprocess
+from tempfile import NamedTemporaryFile
+import mudata
+from pathlib import Path
+import numpy as np
+
+## VIASH START
+meta = {
+    'functionality_name': './target/native/integrate/harmonypy/harmonypy',
+    'resources_dir': './resources_test/pbmc_1k_protein_v3/'
+}
+## VIASH END
+
+resources_dir, functionality_name = meta["resources_dir"], meta["functionality_name"]
+input_file = f"{resources_dir}/pbmc_1k_protein_v3_mms.h5mu"
+
+
+class TestHarmonyPy(unittest.TestCase):
+    def _run_and_check_output(self, args_as_list):
+        try:
+            subprocess.check_output([f"./{functionality_name}"] + args_as_list)
+        except subprocess.CalledProcessError as e:
+            print(e.stdout.decode("utf-8"))
+            raise e
+
+    def test_harmonypy(self):
+        with NamedTemporaryFile('w', suffix=".h5mu") as tempfile_input_file:
+            input_data = mudata.read_h5mu(input_file)
+            mod = input_data.mod['rna']
+            number_of_obs = mod.n_obs
+            mod.obs['batch'] = 'A'
+            column_index = mod.obs.columns.get_indexer(['batch'])
+            mod.obs.iloc[slice(number_of_obs//2, None), column_index] = 'B'
+            input_data.write(tempfile_input_file.name)
+            self._run_and_check_output([
+                "--input", tempfile_input_file.name,
+                "--modality", "rna",
+                "--pca_key", "X_pca",
+                "--output_key_suffix", "harmonypy",
+                "--sample_key", "batch",
+                "--output", "output.h5mu"])
+            self.assertTrue(Path("output.h5mu").is_file())
+            output_data = mudata.read_h5mu("output.h5mu")
+            np.testing.assert_array_equal(output_data.mod['rna'].X.data, input_data.mod['rna'].X.data)
+            np.testing.assert_array_equal(input_data.mod['rna'].obsm['X_pca'], output_data.mod['rna'].obsm['X_pca'])
+            self.assertIn('X_pca_harmonypy', output_data.mod['rna'].obsm)
+            self.assertTupleEqual(output_data.mod['rna'].obsm['X_pca_harmonypy'].shape,
+                                  input_data.mod['rna'].obsm['X_pca'].shape)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/integrate/harmonypy/test.py
+++ b/src/integrate/harmonypy/test.py
@@ -7,46 +7,43 @@ import numpy as np
 
 ## VIASH START
 meta = {
-    'functionality_name': './target/native/integrate/harmonypy/harmonypy',
+    'executable': './target/native/integrate/harmonypy/harmonypy',
     'resources_dir': './resources_test/pbmc_1k_protein_v3/'
 }
 ## VIASH END
 
-resources_dir, functionality_name = meta["resources_dir"], meta["functionality_name"]
-input_file = f"{resources_dir}/pbmc_1k_protein_v3_mms.h5mu"
-
+input_file = f"{meta['resources_dir']}/pbmc_1k_protein_v3_mms.h5mu"
 
 class TestHarmonyPy(unittest.TestCase):
     def _run_and_check_output(self, args_as_list):
         try:
-            subprocess.check_output([f"./{functionality_name}"] + args_as_list)
+            subprocess.check_output([meta['executable']] + args_as_list)
         except subprocess.CalledProcessError as e:
             print(e.stdout.decode("utf-8"))
             raise e
 
     def test_harmonypy(self):
-        with NamedTemporaryFile('w', suffix=".h5mu") as tempfile_input_file:
-            input_data = mudata.read_h5mu(input_file)
-            mod = input_data.mod['rna']
-            number_of_obs = mod.n_obs
-            mod.obs['batch'] = 'A'
-            column_index = mod.obs.columns.get_indexer(['batch'])
-            mod.obs.iloc[slice(number_of_obs//2, None), column_index] = 'B'
-            input_data.write(tempfile_input_file.name)
-            self._run_and_check_output([
-                "--input", tempfile_input_file.name,
-                "--modality", "rna",
-                "--pca_key", "X_pca",
-                "--output_key_suffix", "harmonypy",
-                "--sample_key", "batch",
-                "--output", "output.h5mu"])
-            self.assertTrue(Path("output.h5mu").is_file())
-            output_data = mudata.read_h5mu("output.h5mu")
-            np.testing.assert_array_equal(output_data.mod['rna'].X.data, input_data.mod['rna'].X.data)
-            np.testing.assert_array_equal(input_data.mod['rna'].obsm['X_pca'], output_data.mod['rna'].obsm['X_pca'])
-            self.assertIn('X_pca_harmonypy', output_data.mod['rna'].obsm)
-            self.assertTupleEqual(output_data.mod['rna'].obsm['X_pca_harmonypy'].shape,
-                                  input_data.mod['rna'].obsm['X_pca'].shape)
+        # with NamedTemporaryFile('w', suffix=".h5mu") as tempfile_input_file:
+        input_data = mudata.read_h5mu(input_file)
+        # mod = input_data.mod['rna']
+        # number_of_obs = mod.n_obs
+        # mod.obs['batch'] = 'A'
+        # column_index = mod.obs.columns.get_indexer(['batch'])
+        # mod.obs.iloc[slice(number_of_obs//2, None), column_index] = 'B'
+        # input_data.write(tempfile_input_file.name)
+        self._run_and_check_output([
+            "--input", input_file,
+            "--modality", "rna",
+            "--obsm_input", "X_pca",
+            "--obsm_output", "X_pca_int",
+            "--obs_covariates", "leiden",
+            "--output", "output.h5mu"])
+        self.assertTrue(Path("output.h5mu").is_file())
+        output_data = mudata.read_h5mu("output.h5mu")
+        np.testing.assert_array_equal(output_data.mod['rna'].X.data, input_data.mod['rna'].X.data)
+        np.testing.assert_array_equal(input_data.mod['rna'].obsm['X_pca'], output_data.mod['rna'].obsm['X_pca'])
+        self.assertIn('X_pca_int', output_data.mod['rna'].obsm)
+        self.assertTupleEqual(output_data.mod['rna'].obsm['X_pca_int'].shape, input_data.mod['rna'].obsm['X_pca'].shape)
 
 if __name__ == '__main__':
     unittest.main()

--- a/workflows/integration/multimodal_integration/main.nf
+++ b/workflows/integration/multimodal_integration/main.nf
@@ -51,7 +51,7 @@ workflow test_wf {
   // or when running from s3: params.resources_test = "s3://openpipelines-data/"
   testParams = [
     id: "foo",
-    input: params.resources_test + "/concat/human_brain_3k_filtered_feature_bc_matrix_subset.h5mu",
+    input: params.resources_test + "/concat/concatenated_brain_filtered_feature_bc_matrix_subset.h5mu",
   ]
 
   output_ch =

--- a/workflows/integration/multimodal_integration/main.nf
+++ b/workflows/integration/multimodal_integration/main.nf
@@ -7,6 +7,7 @@ include { pca } from targetDir + '/dimred/pca/main.nf'
 include { find_neighbors } from targetDir + '/neighbors/find_neighbors/main.nf'
 include { umap } from targetDir + '/dimred/umap/main.nf'
 include { leiden } from targetDir + '/cluster/leiden/main.nf'
+include { harmonypy } from targetDir + '/integrate/harmonypy/main.nf'
 
 include { readConfig; viashChannel; helpMessage } from workflowDir + "/utils/WorkflowHelper.nf"
 
@@ -29,6 +30,7 @@ workflow run_wf {
   main:
   output_ch = input_ch
     | pca
+    | harmonypy
     | find_neighbors
     | leiden
     | umap.run(
@@ -49,7 +51,7 @@ workflow test_wf {
   // or when running from s3: params.resources_test = "s3://openpipelines-data/"
   testParams = [
     id: "foo",
-    input: params.resources_test + "/pbmc_1k_protein_v3/pbmc_1k_protein_v3_ums.h5mu",
+    input: params.resources_test + "/concat/human_brain_3k_filtered_feature_bc_matrix_subset.h5mu",
   ]
 
   output_ch =

--- a/workflows/integration/multiomics/main.nf
+++ b/workflows/integration/multiomics/main.nf
@@ -38,11 +38,8 @@ workflow run_wf {
     | map { id, files_list -> assert files_list.size() == 1; [id, files_list.first()] }
     | process_rna_singlesample
     | toSortedList()
-    | map {list -> ["combined_samples_rna", 
-                      ["input": list.collect{it[1]},
-                       "sample_names":  list.collect{it[0]}]
-                    ]}
-    | concat
+    | map { tups -> tups.transpose()}
+    | map {id, files -> [id.join(','), ["id": id, "input": files]]}
     | process_rna_multisample
 
 
@@ -57,7 +54,7 @@ workflow run_wf {
                       ["input": list.collect{it[1]},
                        "sample_names":  list.collect{it[0]}]
                     ]}
-    | concat
+    | concat // concat will be integrated into process_atac_multisample in the future
   
   output_ch = rna_ch.concat(atac_ch)
     | toSortedList()

--- a/workflows/process_rna/multisample/config.vsh.yaml
+++ b/workflows/process_rna/multisample/config.vsh.yaml
@@ -15,12 +15,16 @@ functionality:
     - name: "--id"
       required: true
       type: string
-      description: ID of the sample.
+      multiple_sep: ';'
+      multiple: true
+      description: IDs of the sample.
       example: foo
     - name: "--input"
       required: true
       type: file
-      description: Path to the sample.
+      multiple_sep: ';'
+      multiple: true
+      description: Path to the samples.
       example: dataset.h5mu
   resources:
     - type: nextflow_script

--- a/workflows/process_rna/multisample/integration_test.sh
+++ b/workflows/process_rna/multisample/integration_test.sh
@@ -8,7 +8,7 @@ cd "$REPO_ROOT"
 
 export NXF_VER=21.10.6
 
-nextflow run . \
+bin/nextflow run . \
   -main-script workflows/process_rna/multisample/main.nf \
   -profile docker \
   -resume \

--- a/workflows/resources_test_scripts/download_concat_test_data.sh
+++ b/workflows/resources_test_scripts/download_concat_test_data.sh
@@ -21,11 +21,11 @@ target/docker/download/download_file/download_file \
 --output "${OUT}/human_brain_3k_filtered_feature_bc_matrix.h5"
 
 # Convert to h5mu
-./bin/viash run src/convert/h510x_to_h5mu/config.vsh.yaml --\
+./bin/viash run src/convert/from_10xh5_to_h5mu/config.vsh.yaml -- \
 --input "$OUT/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix.h5" \
 --output "$OUT/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix.h5mu"
 
-./bin/viash run src/convert/h510x_to_h5mu/config.vsh.yaml --\
+./bin/viash run src/convert/from_10xh5_to_h5mu/config.vsh.yaml -- \
 --input "$OUT/human_brain_3k_filtered_feature_bc_matrix.h5" \
 --output "$OUT/human_brain_3k_filtered_feature_bc_matrix.h5mu"
 
@@ -44,4 +44,7 @@ rm "$OUT/human_brain_3k_filtered_feature_bc_matrix.h5"\
    "${OUT}/human_brain_3k_filtered_feature_bc_matrix.h5mu"\
    "${OUT}/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix.h5mu"
 
-
+./bin/viash run src/integrate/concat/config.vsh.yaml -- \
+--input "$OUT/human_brain_3k_filtered_feature_bc_matrix_subset.h5mu,$OUT/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix_subset.h5mu" \
+--sample_names "mouse,human" \
+--output "$OUT/concatenated_brain_filtered_feature_bc_matrix_subset.h5mu"


### PR DESCRIPTION
I compared this implementation with the implementation from #55 
```bash
❯ hyperfine --warmup 1 './target/docker/integrate/harmony/harmony -i mms_with_batch.h5mu  -o ./test.h5mu'
Benchmark 1: ./target/docker/integrate/harmony/harmony -i mms_with_batch.h5mu  -o ./test.h5mu
  Time (mean ± σ):     25.057 s ±  1.703 s    [User: 0.177 s, System: 0.128 s]
  Range (min … max):   23.303 s … 29.393 s    10 runs
```

```bash
❯ hyperfine --warmup 1 './target/docker/integrate/harmonypy/harmonypy -i mms_with_batch.h5mu  -o ./test.h5mu'
Benchmark 1: ./target/docker/integrate/harmonypy/harmonypy -i mms_with_batch.h5mu  -o ./test.h5mu
  Time (mean ± σ):      6.851 s ±  0.399 s    [User: 0.167 s, System: 0.114 s]
  Range (min … max):    6.364 s …  7.703 s    10 runs
```

docker stats for `harmony`
```bash
CONTAINER ID   NAME              CPU %     MEM USAGE / LIMIT    MEM %     NET I/O     BLOCK I/O   PIDS
8f1cb0159f28   gracious_carver   93.59%    431.6MiB / 15.6GiB   2.70%     876B / 0B   0B / 0B     14
```
docker stats for `harmonypy`
```bash
CONTAINER ID   NAME             CPU %     MEM USAGE / LIMIT    MEM %     NET I/O     BLOCK I/O   PIDS
4943d4d26b03   quirky_shirley   964.51%   137.8MiB / 15.6GiB   0.86%     736B / 0B   0B / 0B     20
```