### PR TITLE
`dimred/umap`: Streamline UMAP parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# openpipeline 0.5.1
+
+## MINOR CHANGES
+
+* `dimred/umap`: Streamline UMAP parameters by adding `--obsm_output` parameter to allow choosing the output `.obsm` slot.
+
+
 # openpipeline 0.5.0
 
 Major redesign of the integration and multiomic workflows. Current list of workflows:

--- a/src/dimred/pca/config.vsh.yaml
+++ b/src/dimred/pca/config.vsh.yaml
@@ -42,7 +42,7 @@ functionality:
     - name: "--obsm_output"
       type: string
       default: "X_pca"
-      description: "In which .obsm slot to store the resulting integrated embedding."
+      description: "In which .obsm slot to store the resulting embedding."
 
     - name: "--varm_output"
       type: string

--- a/src/dimred/umap/config.vsh.yaml
+++ b/src/dimred/umap/config.vsh.yaml
@@ -9,79 +9,89 @@ functionality:
       email: ddemaeyer@gmail.com
       roles: [ maintainer ]
       props: { account: ddemaey1 }
-  arguments:
-    # inputs
-    - name: "--input"
-      type: file
-      description: Input h5mu file
-      direction: input
-      required: true
-      example: input.h5mu
+  argument_groups:
+    - name: Inputs
+      arguments:
+        - name: "--input"
+          type: file
+          description: Input h5mu file
+          direction: input
+          required: true
+          example: input.h5mu
 
-    - name: "--modality"
-      type: string
-      multiple: true
-      default: "rna"
-      required: false
+        - name: "--modality"
+          type: string
+          multiple: true
+          default: "rna"
+          required: false
 
-    - name: "--uns_neighbors"
-      type: string
-      default: "neighbors"
-      description: The .uns neighbors slot as output by the `find_neighbors` component.
-
-    # outputs
-    - name: "--output"
-      alternatives: ["-o"]
-      type: file
-      description: Output h5mu file.
-      direction: output
-      required: true
-      example: output.h5mu
-
-    - name: "--output_key"
-      type: string
-      description: The pre/postfix under which to store the UMAP results. # More specifically, .obsm["X_"+key], .uns[key] and .varm["loadings_"+key].
-      default: "umap"
+        - name: "--uns_neighbors"
+          type: string
+          default: "neighbors"
+          description: The `.uns` neighbors slot as output by the `find_neighbors` component.
     
-    # arguments
-    - name: "--min_dist"
-      type: double
-      description: The effective minimum distance between embedded points. Smaller values will result in a more clustered/clumped embedding where nearby points on the manifold are drawn closer together, while larger values will result on a more even dispersal of points. The value should be set relative to the spread value, which determines the scale at which embedded points will be spread out. 
-      default: 0.5
+    - name: Outputs
+      arguments:
+        - name: "--output"
+          alternatives: ["-o"]
+          type: file
+          description: Output h5mu file.
+          direction: output
+          required: true
+          example: output.h5mu
 
-    - name: "--spread"
-      type: double
-      description: The effective scale of embedded points. In combination with min_dist this determines how clustered/clumped the embedded points are.
-      default: 1.0
+        - name: "--obsm_output"
+          type: string
+          description: The pre/postfix under which to store the UMAP results.
+          default: "umap"
+    
+    - name: Arguments
+      arguments:
+        - name: "--min_dist"
+          type: double
+          description: The effective minimum distance between embedded points. Smaller values will result in a more clustered/clumped embedding where nearby points on the manifold are drawn closer together, while larger values will result on a more even dispersal of points. The value should be set relative to the spread value, which determines the scale at which embedded points will be spread out. 
+          default: 0.5
 
-    - name: "--num_components"
-      type: integer
-      description: The number of dimensions of the embedding.
-      default: 2
+        - name: "--spread"
+          type: double
+          description: The effective scale of embedded points. In combination with `min_dist` this determines how clustered/clumped the embedded points are.
+          default: 1.0
 
-    - name: "--max_iter"
-      type: integer
-      description: The number of iterations (epochs) of the optimization.
+        - name: "--num_components"
+          type: integer
+          description: The number of dimensions of the embedding.
+          default: 2
 
-    - name: "--alpha"
-      type: double
-      description: The initial learning rate for the embedding optimization.
-      default: 1.0
+        - name: "--max_iter"
+          type: integer
+          description: The number of iterations (epochs) of the optimization. Called `n_epochs` in the original UMAP.
 
-    - name: "--gamma"
-      type: double
-      description: Weighting applied to negative samples in low dimensional embedding optimization. Values higher than one will result in greater weight being given to negative samples.
-      default: 1.0
+        - name: "--alpha"
+          type: double
+          description: The initial learning rate for the embedding optimization.
+          default: 1.0
 
-    - name: "--negative_sample_rate"
-      type: integer
-      description: The number of negative edge/1-simplex samples to use per positive edge/1-simplex sample in optimizing the low dimensional embedding.
-      default: 5
-      
-    - name: "--init_pos"
-      type: string
-      description: How to initialize the low dimensional embedding. Called init in the original UMAP. Options are paga, spectral and random.
-      default: spectral
+        - name: "--gamma"
+          type: double
+          description: Weighting applied to negative samples in low dimensional embedding optimization. Values higher than one will result in greater weight being given to negative samples.
+          default: 1.0
+
+        - name: "--negative_sample_rate"
+          type: integer
+          description: The number of negative edge/1-simplex samples to use per positive edge/1-simplex sample in optimizing the low dimensional embedding.
+          default: 5
+          
+        - name: "--init_pos"
+          type: string
+          description: |
+            How to initialize the low dimensional embedding. Called `init` in the original UMAP. Options are:
+            
+            * Any key from `.obsm`
+            * `'paga'`: positions from `paga()`
+            * `'spectral'`: use a spectral embedding of the graph
+            * `'random'`: assign initial embedding positions at random.
+
+          default: spectral
   resources:
     - type: python_script
       path: script.py

--- a/src/dimred/umap/run_test.py
+++ b/src/dimred/umap/run_test.py
@@ -1,6 +1,9 @@
 import subprocess
-from os import path
 import muon as mu
+from unittest import TestCase, main
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from mudata import read_h5mu
 
 ## VIASH START
 meta = {
@@ -9,22 +12,60 @@ meta = {
 }
 ## VIASH END
 
+resources_dir, functionality_name = meta["resources_dir"], meta["functionality_name"]
 input = meta["resources_dir"] + "pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu"
-output = "output.h5mu"
 
-cmd_pars = [
-    meta["executable"],
-    "--input", input,
-    "--output", output,
-]
-out = subprocess.check_output(cmd_pars).decode("utf-8")
+class TestPCA(TestCase):
+    def _run_and_check_output(self, args_as_list, expected_raise=False):
+        try:
+            subprocess.check_output([meta['executable']] + args_as_list, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            if not expected_raise:
+                print(e.stdout.decode("utf-8"))
+            raise e
 
-# check if file exists
-assert path.exists("output.h5mu"), "No output was created."
+    def test_pca(self):
+        self._run_and_check_output([
+                "--input", input,
+                "--output",  "output.h5mu",
+                "--obsm_output", "X_foo",
+                "--num_components", "26"
+            ])
+        self.assertTrue(Path("output.h5mu").is_file(), msg="No output was created.")
+        data = mu.read_h5mu("output.h5mu")
 
-# read it with scanpy
-data = mu.read_h5mu("output.h5mu")
+        # check whether pca was found
+        self.assertIn("X_foo", data.mod["rna"].obsm, msg="Check whether output was found in .obsm")
+        self.assertTupleEqual(data.mod["rna"].obsm["X_foo"].shape, (data.n_obs, 26), msg="Check shapes")
 
-# check whether pca was found
-assert "X_umap" in data.mod["rna"].obsm, "Check whether output was found in .obsm"
-assert data.mod["rna"].obsm["X_umap"].shape == (data.n_obs, 2), "Check shapes"
+    def test_selecting_input_layer(self):
+        input_data = read_h5mu(input)
+        input_data.mod['rna'].layers['test'] = input_data.mod['rna'].X
+        with NamedTemporaryFile(suffix=".h5mu") as tempfile:
+            input_data.write_h5mu(tempfile.name)
+            self._run_and_check_output([
+                    "--input", tempfile.name,
+                    "--output",  "output.h5mu",
+                    "--obsm_output", "test_foo",
+                    "--num_components", "26",
+                    "--layer", "test"
+                ])
+            self.assertTrue(Path("output.h5mu").is_file(), msg="No output was created.")
+            data = mu.read_h5mu("output.h5mu")
+            self.assertIn("test_foo", data.mod["rna"].obsm, msg="Check whether output was found in .obsm")
+            self.assertTupleEqual(data.mod["rna"].obsm["test_foo"].shape, (data.n_obs, 26), msg="Check shapes")
+
+    def test_raise_if_input_layer_is_missing(self):
+        with self.assertRaises(subprocess.CalledProcessError) as err:
+            self._run_and_check_output([
+                    "--input", input,
+                    "--output",  "output.h5mu",
+                    "--obsm_output", "X_foo",
+                    "--num_components", "26",
+                    "--uns_neighbors", "does_not_exist"
+                ], expected_raise=True)
+            self.assertIn("ValueError: 'does_not_exist' was not found in .mod['rna'].uns.",
+                          err.exception.stdout)
+
+if __name__ == "__main__":
+    main()

--- a/src/dimred/umap/script.py
+++ b/src/dimred/umap/script.py
@@ -2,13 +2,14 @@ import scanpy as sc
 import muon as mu
 import logging
 from sys import stdout
+import anndata as ad
 
 ## VIASH START
 par = {
-  'input': 'work/ca/588b7fcdfd953a534a59d794671451/pbmc_1k_protein_v3_mms.find_neighbors.output.h5mu',
+  'input': 'resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_mms.h5mu',
   'modality': ['rna'],
   'output': 'output.h5mu',
-  'output_key': 'umap',
+  'obsm_output': 'X_umap',
   'min_dist': 0.5,
   'spread': 1.0,
   'num_components': 2,
@@ -35,8 +36,35 @@ for mod in par['modality']:
     logger.info("Computing UMAP for modality '%s'", mod)
     data = mdata.mod[mod]
 
+    if par['uns_neighbors'] not in data.uns:
+        raise ValueError(f"'{par['uns_neighbors']}' was not found in .mod['{mod}'].uns.")
+
+    # create temporary AnnData
+    # ... because sc.tl.umap doesn't allow to choose
+    # the obsm output slot
+    # ... also we can see scanpy is a data format dependency hell
+    neigh_key = par["uns_neighbors"]
+    temp_uns = { neigh_key: data.uns[neigh_key] }
+    conn_key = temp_uns[neigh_key]['connectivities_key']
+    dist_key = temp_uns[neigh_key]['distances_key']
+    temp_obsp = {
+      conn_key: data.obsp[conn_key],
+      dist_key: data.obsp[dist_key],
+    }
+    pca_key = temp_uns[neigh_key]['params']['use_rep']
+    temp_obsm = {
+      pca_key: data.obsm[pca_key]
+    }
+
+    temp_adata = ad.AnnData(
+      obsm=temp_obsm,
+      obsp=temp_obsp,
+      uns=temp_uns,
+      shape=data.shape
+    )
+
     sc.tl.umap(
-        data,
+        temp_adata,
         min_dist=par["min_dist"],
         spread=par["spread"],
         n_components=par["num_components"],
@@ -45,9 +73,10 @@ for mod in par['modality']:
         gamma=par["gamma"],
         negative_sample_rate=par["negative_sample_rate"],
         init_pos=par["init_pos"],
-        neighbors_key=par["uns_neighbors"]
+        neighbors_key=neigh_key
     )
-    # note: should be able to set the neighbors key
+
+    data.obsm[par['obsm_output']] = temp_adata.obsm['X_umap']
 
 logger.info("Writing to %s.", par["output"])
 mdata.write_h5mu(filename=par["output"])


### PR DESCRIPTION

* `dimred/umap`: Streamline UMAP parameters by adding `--obsm_output` parameter to allow choosing the output `.obsm` slot.

