### PR TITLE
Fix/ci warnings

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,7 +22,7 @@ jobs:
       id: cachehash
       run: |
         AWS_EC2_METADATA_DISABLED=true aws s3 ls $s3_bucket --recursive --no-sign-request > bucket-contents.txt
-        echo "::set-output name=cachehash::resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )"
+        echo "cachehash=resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )" >> $GITHUB_OUTPUT
     
     # initialize cache
     - name: Cache resources data
@@ -64,9 +64,9 @@ jobs:
     - id: set_matrix
       run: |
         component_json=$(bin/viash ns list -p docker --format json | jq -c '[ .[] | { "name": .functionality.name, "config": .info.config } ]')
-        echo "::set-output name=component_matrix::$component_json"
+        echo "component_matrix=$component_json" >> $GITHUB_OUTPUT
         workflow_json=$(bin/viash ns list -s workflows --format json | jq -c '[ .[] | { "name": .functionality.name, "config": .info.config, "test_script": .functionality.test_resources[].path, "entry": .functionality.test_resources[].entrypoint } ]')
-        echo "::set-output name=workflow_matrix::$workflow_json"
+        echo "workflow_matrix=$workflow_json" >> $GITHUB_OUTPUT
     outputs:
       component_matrix: ${{ steps.set_matrix.outputs.component_matrix }}
       workflow_matrix: ${{ steps.set_matrix.outputs.workflow_matrix }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -31,7 +31,7 @@ jobs:
       id: cachehash
       run: |
         AWS_EC2_METADATA_DISABLED=true aws s3 ls $s3_bucket --recursive --no-sign-request > bucket-contents.txt
-        echo "::set-output name=cachehash::resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )"
+        echo "cachehash=resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )" >> $GITHUB_OUTPUT
     
     # initialize cache
     - name: Cache resources data
@@ -89,7 +89,7 @@ jobs:
     - id: set_matrix
       run: |
         component_json=$(bin/viash ns list -p docker --format json | jq -c '[ .[] | { "name": .functionality.name, "namespace": .functionality.namespace, "config": .info.config } ]')
-        echo "::set-output name=component_matrix::$component_json"
+        echo "component_matrix=$component_json" >> $GITHUB_OUTPUT
     outputs:
       component_matrix: ${{ steps.set_matrix.outputs.component_matrix }}
       cachehash: ${{ steps.cachehash.outputs.cachehash }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,7 +33,7 @@ jobs:
       id: cachehash
       run: |
         AWS_EC2_METADATA_DISABLED=true aws s3 ls $s3_bucket --recursive --no-sign-request > bucket-contents.txt
-        echo "::set-output name=cachehash::resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )"
+        echo "cachehash=resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )" >> $GITHUB_OUTPUT
     
     # initialize cache
     - name: Cache resources data
@@ -92,9 +92,9 @@ jobs:
     - id: set_matrix
       run: |
         component_json=$(bin/viash ns list -p docker --format json | jq -c '[ .[] | { "name": .functionality.name, "config": .info.config } ]')
-        echo "::set-output name=component_matrix::$component_json"
+        echo "component_matrix=$component_json" >> $GITHUB_OUTPUT
         workflow_json=$(bin/viash ns list -s workflows --format json | jq -c '[ .[] | { "name": .functionality.name, "config": .info.config, "test_script": .functionality.test_resources[].path, "entry": .functionality.test_resources[].entrypoint } ]')
-        echo "::set-output name=workflow_matrix::$workflow_json"
+        echo "workflow_matrix=$workflow_json" >> $GITHUB_OUTPUT
     outputs:
       component_matrix: ${{ steps.set_matrix.outputs.component_matrix }}
       workflow_matrix: ${{ steps.set_matrix.outputs.workflow_matrix }}

--- a/.github/workflows/viash-test.yml
+++ b/.github/workflows/viash-test.yml
@@ -18,9 +18,9 @@ jobs:
           pull_request=$(gh pr list -R openpipelines-bio/openpipeline -H ${{ github.ref_name }} --json url --state open --limit 1 | jq '.[0].url')
           # If the branch has a PR and this run was triggered by a push event, do not run
           if [[ "$pull_request" != "null" && "${{ github.event_name == 'push' }}" == "true" && "${{ !contains(github.event.head_commit.message, 'ci force') }}" == "true" ]]; then
-            echo "::set-output name=check::false"
+            echo "check=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=check::true"
+            echo "check=true" >> $GITHUB_OUTPUT
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GTHB_PAT }}
@@ -52,7 +52,7 @@ jobs:
       id: cachehash
       run: |
         AWS_EC2_METADATA_DISABLED=true aws s3 ls $s3_bucket --recursive --no-sign-request > bucket-contents.txt
-        echo "::set-output name=cachehash::resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )"
+        echo "cachehash=resources_test__$( md5sum bucket-contents.txt | awk '{ print $1 }' )" >> $GITHUB_OUTPUT
     
     # initialize cache
     - name: Cache resources data
@@ -110,7 +110,7 @@ jobs:
           done
         done
         json=$(jq -cs '.' <<< "${result_array_matrix[*]}")
-        echo "::set-output name=matrix::$json"
+        echo "matrix=$json" >> $GITHUB_OUTPUT
 
   # phase 2
   viash_test:

--- a/bin/init_tools
+++ b/bin/init_tools
@@ -12,12 +12,14 @@ function clean_up {
 }
 trap clean_up EXIT
 
+VERSION=0.1.0
+
 if [ $# -eq 2 ]; then
-  git clone https://$1:$2@github.com/viash-io/viash_tools.git $tmpdir/
+  git clone --depth 1 --branch $VERSION https://$1:$2@github.com/viash-io/viash_tools.git $tmpdir/
 else
-  git clone git@github.com:viash-io/viash_tools.git $tmpdir/
+  git clone --depth 1 --branch $VERSION git@github.com:viash-io/viash_tools.git $tmpdir/
 fi
 
 [ -d bin/tools ] && rm -r bin/tools
 
-bin/viash ns build -s $tmpdir/src -t bin/tools
+cp -r $tmpdir/target bin/tools


### PR DESCRIPTION
* Fix ci warnings
* Update to viash_tools 0.1.0. Since published docker containers are used instead of building them from scratch, this reduces CI processing times by about a minute