### PR TITLE
remove ci skip

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -10,7 +10,6 @@ jobs:
     env:
       s3_bucket: s3://openpipelines-data/
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     steps:
     - uses: actions/checkout@v3
@@ -99,7 +98,6 @@ jobs:
     needs: list_components
 
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/viash-test.yml
+++ b/.github/workflows/viash-test.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   run_ci_check_job:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-latest
     outputs:
       run_ci: ${{ steps.github_cli.outputs.check }}
@@ -32,7 +31,7 @@ jobs:
     env:
       s3_bucket: s3://openpipelines-data/
     runs-on: ubuntu-latest
-    if: "(!contains(github.event.head_commit.message, 'ci skip')) && needs.run_ci_check_job.outputs.run_ci == 'true'"
+    if: "needs.run_ci_check_job.outputs.run_ci == 'true'"
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
       cachehash: ${{ steps.cachehash.outputs.cachehash }}


### PR DESCRIPTION
We don't actually need this check. From [docs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs):

> Workflows that would otherwise be triggered using on: push or on: pull_request won't be triggered if you add any of the following strings to the commit message in a push, or the HEAD commit of a pull request:
> 
>     [skip ci]
>     [ci skip]
>     [no ci]
>     [skip actions]
>     [actions skip]
