### PR TITLE
PCA: fix 'variance' slot containing a second copy of the variance ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `workflows/integration`: `init_pos` is no longer set to the integration layer (e.g. `X_pca_integrated`).
 
+* `dimred/pca`: fix `variance` slot containing a second copy of the variance ratio matyrix and not the variances.
+
 # openpipelines 0.7.0
 
 ## MAJOR CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * `workflows/integration`: `init_pos` is no longer set to the integration layer (e.g. `X_pca_integrated`).
 
-* `dimred/pca`: fix `variance` slot containing a second copy of the variance ratio matyrix and not the variances.
+* `dimred/pca`: fix `variance` slot containing a second copy of the variance ratio matrix and not the variances.
 
 ## MINOR CHANGES
 

--- a/src/dimred/pca/run_test.py
+++ b/src/dimred/pca/run_test.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path
 from mudata import read_h5mu
 import re
+import numpy as np
 import sys
 
 ## VIASH START
@@ -38,6 +39,9 @@ def test_pca(run_component):
     assert "pca_variance" in data.mod['rna'].uns
     assert "pca_loadings" in data.mod['rna'].varm
     assert "X_foo" in data.mod['rna'].obsm
+    # GH298
+    assert not np.array_equal(data.mod['rna'].uns['pca_variance']['variance'],
+                              data.mod['rna'].uns['pca_variance']['variance_ratio'])
 
 def test_no_overwrite_but_field_also_not_present(run_component, tmp_path):
     input_data = read_h5mu(input)

--- a/src/dimred/pca/script.py
+++ b/src/dimred/pca/script.py
@@ -71,7 +71,7 @@ for parameter_name, field in check_exist_dict.items():
 
 data.obsm[par["obsm_output"]] = output_adata.obsm['X_pca']
 data.varm[par["varm_output"]] = output_adata.varm['PCs']
-data.uns[par["uns_output"]] = { "variance": output_adata.uns['pca']['variance_ratio'],
+data.uns[par["uns_output"]] = { "variance": output_adata.uns['pca']['variance'],
                                 "variance_ratio": output_adata.uns['pca']['variance_ratio'] }
 
 


### PR DESCRIPTION


Please check when the following items have been completed:

- [x] Conforms to [Contributor's guide](https://openpipelines.bio/contribute)
- [x] Closes #298 (Replace xxxx with the GitHub issue number)
- [x] Tests added
- [x] Component tests passed
- [x] Workflows tests passed
- [x] Changelog entry added
