### PR TITLE
Rename 'crispr' and 'hashing' modalities to 'gdo' and 'hto' respectively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * `velocity/scvelo`: bump anndata from <0.8 to 0.9.
 
-* The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively ([#391](https://github.com/openpipelines-bio/openpipeline/issues/391)).
+* The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively ([#392](https://github.com/openpipelines-bio/openpipeline/pull/392)).
 
 ## NEW FUNCTIONALITY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# openpipelines 0.9.0
+
+## BREAKING CHANGES
+
+* The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively ([#392](https://github.com/openpipelines-bio/openpipeline/pull/392)).
+
 # openpipelines 0.8.0
 
 ## BREAKING CHANGES
@@ -9,8 +15,6 @@
   - `prot_max_vars_per_cell` was renamed to `prot_max_proteins_per_cell`
 
 * `velocity/scvelo`: bump anndata from <0.8 to 0.9.
-
-* The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively ([#392](https://github.com/openpipelines-bio/openpipeline/pull/392)).
 
 ## NEW FUNCTIONALITY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * `velocity/scvelo`: bump anndata from <0.8 to 0.9.
 
+* The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively ([#391](https://github.com/openpipelines-bio/openpipeline/issues/391)).
+
 ## NEW FUNCTIONALITY
 
 * Added an extra label `veryhighmem` mostly for `cellranger_multi` with a large number of samples.

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -86,8 +86,8 @@ def process_counts(counts_folder: Path):
             "VDJ": "vdj",
             "VDJ-T": "vdj_t",
             "VDJ-B": "vdj_b",
-            "CRISPR Guide Capture": "crispr",
-            "Multiplexing Capture": "hashing"
+            "CRISPR Guide Capture": "gdo",
+            "Multiplexing Capture": "hto"
         })
     return mudata.MuData(adata, feature_types=feature_types)
 


### PR DESCRIPTION


## Changelog

The `cripr` and `hashing` modalities have been renamed to `gdo` and `hto` respectively

## Issue ticket number and link
Closes #391 (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [x] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!