### PR TITLE
Fix indexing issue when MuData object contain non overlapping modalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The old behavior of the `full_pipeline` can be obtained by running `full_pipelin
 
 * `annotate/popv`: Fix concat issue when the input data has multiple layers (#395, PR #397).
 
+* `annotate/popv`: Fix indexing issue when MuData object contain non overlapping modalities (PR #405).
 
 # openpipelines 0.8.0
 

--- a/src/annotate/popv/script.py
+++ b/src/annotate/popv/script.py
@@ -175,7 +175,7 @@ def main(par, meta):
             methods=par["methods"]
         )
 
-    popv_input = pq.adata[input.obs_names]
+    popv_input = pq.adata[input_modality.obs_names]
 
     # select columns starting with "popv_"
     popv_obs_cols = popv_input.obs.columns[popv_input.obs.columns.str.startswith("popv_")]

--- a/src/annotate/popv/test.py
+++ b/src/annotate/popv/test.py
@@ -3,6 +3,11 @@ import os
 import pytest
 import mudata as mu
 
+## VIASH START
+meta = {
+    "resources_dir": "resources_test"
+}
+## VIASH END
 
 input_file = f"{meta['resources_dir']}/pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"
 reference_file = f"{meta['resources_dir']}/annotation_test_data/TS_Blood_filtered.h5ad"
@@ -34,6 +39,29 @@ def test_popv_with_other_layer(run_component, tmp_path):
     input_h5mu = mu.read(input_file)
     input_h5mu.mod['rna'].layers['test'] = input_h5mu.mod['rna'].X.copy()
     input_h5mu.write_h5mu(tmp_path / "input.h5mu")
+    run_component([
+        "--input", tmp_path / "input.h5mu",
+        "--reference", reference_file,
+        "--output", "output.h5mu",
+        "--methods", "rf:svm"
+    ])
+
+def test_popv_with_non_overlapping_cells(run_component, tmp_path):
+    input_h5mu = mu.read(input_file)
+    
+    # copy previous modalities
+    rna_ad = input_h5mu.mod["rna"].copy()
+    prot_ad = input_h5mu.mod["prot"].copy()
+
+    # change obs_names such that the cells do not overlap
+    rna_ad.obs_names = [f"rna_{x}" for x in rna_ad.obs_names]
+    prot_ad.obs_names = [f"prot_{x}" for x in prot_ad.obs_names]
+
+    # write new h5mu to file
+    new_h5mu = mu.MuData({"rna": rna_ad, "prot": prot_ad})
+    new_h5mu.write_h5mu(tmp_path / "input.h5mu")
+
+    # run component
     run_component([
         "--input", tmp_path / "input.h5mu",
         "--reference", reference_file,


### PR DESCRIPTION

## Changelog

* Fix indexing issue when MuData object contain non overlapping modalities.
* Added test for checking whether component can run when modalities contain non overlapping cells


## Issue ticket number and link
~Closes #xxxx~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!