### PR TITLE
Fix passing add_id_make_observation_keys_unique parameter in full pipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The old behavior of the `full_pipeline` can be obtained by running `full_pipelin
 
 * `integrate/scvi`: the max_epochs is no longer required since it has a default value (PR #396).
 
+* `workflows/full_pipeline`: fix `make_observation_keys_unique` parameter not being correctly passed to the `add_id` component, causing `ValueError: Observations are not unique across samples` during execution of the `concat` component.
+
 # openpipelines 0.8.0
 
 ## BREAKING CHANGES

--- a/workflows/multiomics/full_pipeline/main.nf
+++ b/workflows/multiomics/full_pipeline/main.nf
@@ -37,7 +37,7 @@ workflow run_wf {
     | preprocessInputs("config": config)
     | setWorkflowArguments (
         "add_id_args": ["input": "input",
-                        "make_observation_keys_unique": "make_observation_keys_unique",
+                        "make_observation_keys_unique": "add_id_make_observation_keys_unique",
                         "obs_output": "add_id_obs_output",
                         "add_id_to_obs": "add_id_to_obs"],
         "split_modalities_args": [:],


### PR DESCRIPTION


## Changelog

Fix `make_observation_keys_unique` parameter not being correctly passed to the `add_id` component, causing `ValueError: Observations are not unique across samples` during execution of the `concat` component.


## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!