### PR TITLE
Do not load viashpy again in pytest unittests.

### DIFF
--- a/src/dataflow/concat/test_concat.py
+++ b/src/dataflow/concat/test_concat.py
@@ -357,4 +357,4 @@ def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
                      err.value.stdout.decode('utf-8'))
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/dimred/pca/run_test.py
+++ b/src/dimred/pca/run_test.py
@@ -158,4 +158,4 @@ def test_output_field_already_present_raises(run_component):
     assert error_found
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/filter/do_filter/run_test.py
+++ b/src/filter/do_filter/run_test.py
@@ -123,4 +123,4 @@ def test_nonexisting_column_raises(run_component,
     assert re.search(r"\.mod\[rna\]\.var\[doesnotexist\] does not exist\.",
         err.value.stdout.decode('utf-8'))
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/filter/filter_with_counts/run_test.py
+++ b/src/filter/filter_with_counts/run_test.py
@@ -175,4 +175,4 @@ def test_filter_mitochondrial_column_not_set(run_component, input_path,
 
 
 if __name__ == "__main__":
-    exit(pytest.main([__file__], plugins=["viashpy"]))
+    exit(pytest.main([__file__]))

--- a/src/filter/filter_with_hvg/run_test.py
+++ b/src/filter/filter_with_hvg/run_test.py
@@ -145,4 +145,4 @@ def test_filter_with_hvg_cell_ranger_unfiltered_data_change_error_message(run_co
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/filter/filter_with_scrublet/test.py
+++ b/src/filter/filter_with_scrublet/test.py
@@ -160,4 +160,4 @@ def test_doublet_automatic_threshold_detection_fails_recovery(run_component, inp
     assert not mu_out.mod['rna'].obs['filter_with_scrublet'].any()
 
 if __name__ == '__main__':
-    exit(pytest.main([__file__], plugins=["viashpy"]))
+    exit(pytest.main([__file__]))

--- a/src/filter/remove_modality/test.py
+++ b/src/filter/remove_modality/test.py
@@ -28,4 +28,4 @@ def test_remove_component(run_component):
     assert list(output.mod.keys()) == ["prot"]
 
 if __name__ == '__main__':
-    exit(pytest.main([__file__], plugins=["viashpy"]))
+    exit(pytest.main([__file__]))

--- a/src/qc/calculate_qc_metrics/test_qc_metrics.py
+++ b/src/qc/calculate_qc_metrics/test_qc_metrics.py
@@ -129,4 +129,4 @@ def test_compare_scanpy(run_component,
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/transform/log1p/run_test.py
+++ b/src/transform/log1p/run_test.py
@@ -71,4 +71,4 @@ def test_1logp(run_component, input_path, output_layer):
     assert 'log1p' in rna_out.uns
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__], plugins=["viashpy"]))
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Changelog

Do not load viashpy again in pytest unittests. Avoids pytest warning.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- ~[ ] Proposed changes are described in the CHANGELOG.md~

- [x] CI tests succeed!