### PR TITLE
Do not add sample ID twice when running multisample pipeline as a subpipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ The old behavior of the `full_pipeline` can be obtained by running `full_pipelin
 
 * `annotate/popv`: now sets `aprox` to `False` to avoid using `annoy` in scanorama because it fails on processors that are missing the AVX-512 instruction sets, causing `Illegal instruction (core dumped)`.
 
+* `workflows/full_pipeline`: Avoid adding sample names to observation ids twice (PR #457). 
+
 # openpipelines 0.8.0
 
 ## BREAKING CHANGES


### PR DESCRIPTION
## Changelog

Do not add sample ID twice when running multisample pipeline as a subpipeline.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!