### PR TITLE
Reduce concat memory consumption by only concatenating one modality at a time.

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,9 +90,7 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
-
+    
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4
@@ -135,8 +133,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
         
     - uses: actions/checkout@v3
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
     
     - uses: actions/checkout@v3
 
@@ -132,7 +132,7 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
         
     - uses: actions/checkout@v3
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,7 +90,9 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-    
+      with:
+        remove-swap: false
+
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4
@@ -133,6 +135,8 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
+      with:
+        remove-swap: false
         
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -86,6 +86,7 @@ jobs:
     - uses: data-intuitive/reclaim-the-bytes@v1
       with:
         remove-swap: false
+
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -84,8 +84,7 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
+
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -84,7 +84,8 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-
+      with:
+        remove-swap: false
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -86,7 +86,6 @@ jobs:
     - uses: data-intuitive/reclaim-the-bytes@v1
       with:
         remove-swap: false
-
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -113,8 +113,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -160,8 +158,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -233,9 +229,7 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
-
+  
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -113,8 +113,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v2
-      with:
-        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -160,8 +158,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v2
-      with:
-        remove-swap: false
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -113,6 +113,8 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
+      with:
+        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -158,6 +160,8 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
+      with:
+        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -229,7 +233,9 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-  
+      with:
+        remove-swap: false
+
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -112,7 +112,9 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
+      with:
+        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -157,7 +159,9 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
+      with:
+        remove-swap: false
 
     - uses: actions/checkout@v3
 
@@ -228,8 +232,8 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
-  
+    - uses: data-intuitive/reclaim-the-bytes@v2
+
     - uses: actions/checkout@v3
 
     - uses: viash-io/viash-actions/setup@v4

--- a/.github/workflows/viash-test.yml
+++ b/.github/workflows/viash-test.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
+      with:
+        remove-swap: false
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/viash-test.yml
+++ b/.github/workflows/viash-test.yml
@@ -96,8 +96,6 @@ jobs:
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
     - uses: data-intuitive/reclaim-the-bytes@v1
-      with:
-        remove-swap: false
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/viash-test.yml
+++ b/.github/workflows/viash-test.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
     # Remove unnecessary files to free up space. Otherwise, we get 'no space left on device.'
-    - uses: data-intuitive/reclaim-the-bytes@v1
+    - uses: data-intuitive/reclaim-the-bytes@v2
 
     - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * `full_pipeline`: default value for `--var_qc_metrics` is now the combined values specified for `--mitochondrial_gene_regex` and `--filter_with_hvg_var_output`.
 
+* `dataflow/concat`: reduce memory consumption by only reading one modality at the same time (PR #474). 
+
 ## NEW FUNCTIONALITY
 
 * `filter/filter_with_counts`: add `--var_name_mitochondrial_genes` argument to store a boolean array corresponding the detected mitochondrial genes.

--- a/src/dataflow/concat/script.py
+++ b/src/dataflow/concat/script.py
@@ -7,6 +7,8 @@ import pandas as pd
 import numpy as np
 from collections.abc import Iterable
 from multiprocessing import Pool
+from pathlib import Path
+import h5py
 
 ### VIASH START
 par = {
@@ -34,25 +36,11 @@ def indexes_unique(indices: Iterable[pd.Index]) -> bool:
     combined_indices = indices[0].append(indices[1:])
     return combined_indices.is_unique
 
-def check_observations_unique(samples: Iterable[mu.MuData]) -> None:
+def check_observations_unique(samples: Iterable[anndata.AnnData]) -> None:
     observation_ids = [sample.obs.index for sample in samples]
     if not indexes_unique(observation_ids):
         raise ValueError("Observations are not unique across samples.")
 
-def group_modalities(samples: Iterable[anndata.AnnData]) -> dict[str, anndata.AnnData]:
-    """
-    Split up the modalities of all samples and group them per modality.
-    """
-    mods = {}
-    for sample in samples:
-        for mod_name, mod in sample.mod.items():
-            mods.setdefault(mod_name, []).append(mod)
-
-    if len(set(len(mod) for mod in mods.values())) != 1:
-        logger.warning("One or more samples seem to have a different number of modalities.")
-
-    logger.info("Successfully sorted modalities for the different samples.")
-    return mods
 
 def nunique(row):
     unique = pd.unique(row)
@@ -167,15 +155,13 @@ def split_conflicts_modalities(n_processes: int, input_ids: tuple[str], modaliti
             concatenated_result[matrix_name] = concatenated_matrix
         return conflicts_result, concatenated_result
 
-def set_matrices(concatenated_data: mu.MuData,
-                 mod_name: str,
+def set_matrices(mod: mu.MuData,
                  new_matrices: dict[str, pd.DataFrame | None]) -> mu.MuData:
     """
     Add the calculated matrices to the mudata object. Ensure the correct datatypes
     for the matrices that are composed from the combination of the matrices
     from the different modalities.
     """
-    mod = concatenated_data.mod[mod_name]
     for matrix_name, data in new_matrices.items():
         new_index = getattr(mod, matrix_name).index
         if data is None:
@@ -183,23 +169,15 @@ def set_matrices(concatenated_data: mu.MuData,
         if data.index.empty:
             data.index = new_index
         setattr(mod, matrix_name, data)
-    # After setting the matrices (.e.g. .mod['rna'].var) for each of the modalities
-    # the 'global' matrices must also be updated. This is done by mudata automatically
-    # by calling mudata.update() before writing. However, we need to make sure that the
-    # dtypes of these global matrices are also correct for writing..
-    for global_matrix_name in new_matrices.keys():
-        matrix = getattr(concatenated_data, global_matrix_name)
-        setattr(concatenated_data, global_matrix_name, cast_to_writeable_dtype(matrix))
-    return concatenated_data
+    return mod
 
-def set_conflicts(concatenated_data: mu.MuData,
-                  mod_name: str,
+
+def set_conflicts(mod: anndata.AnnData,
                   conflicts: dict[str, dict[str, pd.DataFrame]]) -> mu.MuData:
     """
     Store dataframes containing the conflicting columns in .obsm,
     one key per column name from the original data.
     """
-    mod = concatenated_data.mod[mod_name]
     mutlidim_to_singledim = {
         'varm': 'var',
         'obsm': 'obs'
@@ -209,10 +187,35 @@ def set_conflicts(concatenated_data: mu.MuData,
             singledim_name = mutlidim_to_singledim[conflict_matrix_name]
             singledim_index = getattr(mod, singledim_name).index
             getattr(mod, conflict_matrix_name)[conflict_name] = conflict_data.reindex(singledim_index)
-    concatenated_data.update()
+    return mod
+
+def concatenate_modality(n_processes: int, mod: str, input_files: Iterable[str | Path], 
+                         other_axis_mode: str, input_ids: tuple[str]) -> anndata.AnnData:
+    
+    concat_modes = {
+        "move": None,
+    }
+    other_axis_mode_to_apply = concat_modes.get(other_axis_mode, other_axis_mode)
+
+    mod_data = []
+    for input_file in input_files:
+        try:
+            mod_data.append(mu.read_h5ad(input_file, mod=mod))
+        except KeyError as e: # Modality does not exist for this sample, skip it
+            if f"Unable to open object '{mod}' doesn't exist" not in str(e):
+                raise e
+            pass
+    check_observations_unique(mod_data)
+
+    concatenated_data = anndata.concat(mod_data, join='outer', merge=other_axis_mode_to_apply)
+
+    if other_axis_mode == "move":
+        conflicts, new_matrices = split_conflicts_modalities(n_processes, input_ids, mod_data)
+        concatenated_data = set_conflicts(concatenated_data, conflicts)
+        concatenated_data = set_matrices(concatenated_data, new_matrices)
     return concatenated_data
 
-def concatenate_modalities(n_processes: int, modalities: dict[str, Iterable[anndata.AnnData]],
+def concatenate_modalities(n_processes: int, modalities: set[str], input_files: Path | str,
                            other_axis_mode: str, input_ids: tuple[str] | None = None) -> mu.MuData:
     """
     Join the modalities together into a single multimodal sample.
@@ -220,38 +223,36 @@ def concatenate_modalities(n_processes: int, modalities: dict[str, Iterable[annd
     logger.info('Concatenating samples.')
     if other_axis_mode == "move" and not input_ids:
         raise ValueError("--mode 'move' requires --input_ids.")
-    concat_modes = {
-        "move": None,
-    }
-    other_axis_mode_to_apply = concat_modes.get(other_axis_mode, other_axis_mode)
-    new_mods = {mod_name: anndata.concat(modes,
-                                         join='outer',
-                                         merge=other_axis_mode_to_apply)
-                for mod_name, modes in modalities.items()}
+    new_mods = {}
+    for mod_name in modalities:
+        new_mods[mod_name] = concatenate_modality(n_processes, mod_name, input_files, other_axis_mode, input_ids)
     concatenated_data = mu.MuData(new_mods)
-    logger.info('Concatenated data shape: %s', concatenated_data.shape)
-    if other_axis_mode == "move":
-        for mod_name, modes in modalities.items():
-            conflicts, new_matrices = split_conflicts_modalities(n_processes, input_ids, modes)
-            concatenated_data = set_conflicts(concatenated_data, mod_name, conflicts)
-            concatenated_data = set_matrices(concatenated_data, mod_name, new_matrices)
+
+    # After setting the matrices (.e.g. .mod['rna'].var) for each of the modalities
+    # the 'global' matrices must also be updated. This is done by mudata automatically
+    # by calling mudata.update() before writing. However, we need to make sure that the
+    # dtypes of these global matrices are also correct for writing..
+    for global_matrix_name in ("var", "obs"):
+        matrix = getattr(concatenated_data, global_matrix_name)
+        setattr(concatenated_data, global_matrix_name, cast_to_writeable_dtype(matrix))
     logger.info("Concatenation successful.")
     return concatenated_data
 
 
 def main() -> None:
-    # Read in sample names and sample .h5mu files
-    samples: list[mu.MuData] = []
+    # Get a list of all possible modalities
+    mods = set()
     for path in par["input"]:
         try:
-            samples.append(mu.read(path.strip()))
-        except ValueError as e:
-            raise ValueError(f"Failed to load {path}.") from e
+            with h5py.File(path, 'r') as f_root:
+                mods = mods | set(f_root["mod"].keys())
+        except OSError:
+            raise OSError(f"Failed to load {path}. Is it a valid h5 file?")
 
     input_ids = None
     if par["input_id"]:
         input_ids: tuple[str] = tuple(i.strip() for i in par["input_id"])
-        if len(input_ids) != len(samples):
+        if len(input_ids) != len(par["input"]):
             raise ValueError("The number of sample names must match the number of sample files.")
 
         if len(set(input_ids)) != len(input_ids):
@@ -260,11 +261,10 @@ def main() -> None:
     logger.info("\nConcatenating data from paths:\n\t%s",
                 "\n\t".join(par["input"]))
 
-    check_observations_unique(samples)
-    mods = group_modalities(samples)
     n_processes = meta["cpus"] if meta["cpus"] else 1
     concatenated_samples = concatenate_modalities(n_processes,
                                                   mods,
+                                                  par["input"],
                                                   par["other_axis_mode"],
                                                   input_ids=input_ids)
     logger.info("Writing out data to '%s' with compression '%s'.",

--- a/src/dataflow/concat/test_concat.py
+++ b/src/dataflow/concat/test_concat.py
@@ -353,7 +353,7 @@ def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
                 "--other_axis_mode", "move",
                 "---cpus", str(meta["cpus"])
                 ])
-    assert re.search(rf"ValueError: Failed to load .*{str(empty_file.name)}\.",
+    assert re.search(rf"OSError: Failed to load .*{str(empty_file.name)}\. Is it a valid h5 file?",
                      err.value.stdout.decode('utf-8'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Changelog

Reduce concat memory consumption by only concatenating one modality at a time.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!