### PR TITLE
Fix '--obs_cluster' argument for leiden_harmony and leiden_scanorama.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 
 * Fix incorrect namespaces of the integration pipelines (PR #464).
 
-* Fix an issue in several workflows where the `--output` argument would not work (PR #476).
+* Fix an issue in several workflows where the `--output` argument would not work (PR #476).'
+
+* `integration/harmony_leiden` and `integration/scanorama_leiden`: Fix an issue where the prefix of the columns that store the leiden clusters was hardcoded to `leiden`, instead of adapting to the value for `--obs_cluster`
 
 # openpipelines 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@
 
 * Fix incorrect namespaces of the integration pipelines (PR #464).
 
-* Fix an issue in several workflows where the `--output` argument would not work (PR #476).'
+* Fix an issue in several workflows where the `--output` argument would not work (PR #476).
 
-* `integration/harmony_leiden` and `integration/scanorama_leiden`: Fix an issue where the prefix of the columns that store the leiden clusters was hardcoded to `leiden`, instead of adapting to the value for `--obs_cluster`
+* `integration/harmony_leiden` and `integration/scanorama_leiden`: Fix an issue where the prefix of the columns that store the leiden clusters was hardcoded to `leiden`, instead of adapting to the value for `--obs_cluster` (PR #482). 
 
 # openpipelines 0.9.0
 

--- a/workflows/multiomics/integration/harmony_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/harmony_leiden/config.vsh.yaml
@@ -79,7 +79,10 @@ functionality:
       arguments:
         - name: "--obs_cluster"
           type: string
-          description: Name of the .obs key under which to add the cluster labels.
+          description: |
+            Prefix for the .obs keys under which to add the cluster labels. Newly created columns in .obs will 
+            be created from the specified value for '--obs_cluster' suffixed with an underscore and one of the resolutions
+            resolutions specified in '--leiden_resolution'.
           default: "harmony_integration_leiden"
         - name: "--leiden_resolution"
           type: double

--- a/workflows/multiomics/integration/harmony_leiden/main.nf
+++ b/workflows/multiomics/integration/harmony_leiden/main.nf
@@ -48,7 +48,7 @@ workflow run_wf {
       ],
       clustering: [
         "obsp_connectivities": "obsp_neighbor_connectivities",
-        "obs_name": "obs_cluster",
+        "obsm_name": "obs_cluster",
         "resolution": "leiden_resolution",
         "modality": "modality"
       ],
@@ -59,6 +59,7 @@ workflow run_wf {
         "modality": "modality"
       ],
       move_obsm_to_obs_leiden: [
+        "obsm_key": "obs_cluster",
         "modality": "modality",
         "output": "output",
       ]
@@ -68,7 +69,7 @@ workflow run_wf {
     | getWorkflowArguments(key: "neighbors")
     | find_neighbors
     | getWorkflowArguments(key: "clustering")
-    | leiden.run(args: [obsm_name: "leiden"])
+    | leiden
     | getWorkflowArguments(key: "umap")
     | umap
     | getWorkflowArguments(key: "move_obsm_to_obs_leiden")

--- a/workflows/multiomics/integration/scanorama_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/scanorama_leiden/config.vsh.yaml
@@ -91,7 +91,10 @@ functionality:
       arguments:
         - name: "--obs_cluster"
           type: string
-          description: Name of the .obs key under which to add the cluster labels.
+          description: |
+            Prefix for the .obs keys under which to add the cluster labels. Newly created columns in .obs will 
+            be created from the specified value for '--obs_cluster' suffixed with an underscore and one of the
+            resolutions specified in '--leiden_resolution'.
           default: "scanorama_integration_leiden"
         - name: "--leiden_resolution"
           type: double

--- a/workflows/multiomics/integration/scanorama_leiden/main.nf
+++ b/workflows/multiomics/integration/scanorama_leiden/main.nf
@@ -48,7 +48,7 @@ workflow run_wf {
       ],
       clustering: [
         "obsp_connectivities": "obsp_neighbor_connectivities",
-        "obs_name": "obs_cluster",
+        "obsm_name": "obs_cluster",
         "resolution": "leiden_resolution",
         "modality": "modality"
 
@@ -61,6 +61,7 @@ workflow run_wf {
 
       ],
       move_obsm_to_obs_leiden: [
+        "obsm_key": "obs_cluster",
         "output": "output"
       ]
     )
@@ -69,12 +70,12 @@ workflow run_wf {
     | getWorkflowArguments(key: "neighbors")
     | find_neighbors
     | getWorkflowArguments(key: "clustering")
-    | leiden.run(args: [obsm_name: "leiden"])
+    | leiden
     | getWorkflowArguments(key: "umap")
     | umap
     | getWorkflowArguments(key: "move_obsm_to_obs_leiden")
     | move_obsm_to_obs.run(
-        args: [ obsm_key: "leiden", output_compression: "gzip" ],     
+        args: [ output_compression: "gzip" ],     
         auto: [ publish: true ]
     )
 


### PR DESCRIPTION
## Changelog

Fix '--obs_cluster' argument for leiden_harmony and leiden_scanorama.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!