### PR TITLE
Add more arguments for input preprocessing to scvi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * `full_pipeline` and `rna_singlesample` pipelines: add `--var_name_mitochondrial_genes`,  `--var_gene_names` and `--mitochondrial_gene_regex` arguments to specify mitochondrial gene detection behaviour.
 
+* `integrate/scvi`: Add `--obs_labels`, `--obs_size_factor`, `--obs_categorical_covariate` and `--obs_continuous_covariate` arguments (PR #496).
+
 * Added `var_qc_metrics_fill_na_value` argument to `calculate_qc_metrics` (PR #477).
 
 * Added `multiomics/multisample` pipeline to run multisample processing followed by the integration setup. It is considered an entrypoint into the full pipeline which skips the single-sample processing. The idea is to allow a a re-run of these steps after a sample has already been processed by the `full_pipeline`. Keep in mind that samples that are provided as input to this pipeline are processed separately and are not concatenated. Hence, the input should be a concatenated sample (PR #475).  

--- a/src/integrate/scvi/config.vsh.yaml
+++ b/src/integrate/scvi/config.vsh.yaml
@@ -36,6 +36,38 @@ functionality:
           type: string
           required: false
           description: ".var column containing highly variable genes. By default, do not subset genes."
+        - name: "--obs_labels"
+          type: string
+          required: false
+          description: |
+            Key in adata.obs for label information. Categories will automatically be 
+            converted into integer categories and saved to adata.obs['_scvi_labels'].
+            If None, assigns the same label to all the data.
+        - name: "--obs_size_factor"
+          type: string
+          required: false
+          description: |
+            Key in adata.obs for size factor information. Instead of using library size as a size factor,
+            the provided size factor column will be used as offset in the mean of the likelihood.
+            Assumed to be on linear scale.
+        - name: "--obs_categorical_covariate"
+          type: string
+          required: false
+          multiple: true
+          description: |
+            Keys in adata.obs that correspond to categorical data. These covariates can be added in
+            addition to the batch covariate and are also treated as nuisance factors
+            (i.e., the model tries to minimize their effects on the latent space).
+            Thus, these should not be used for biologically-relevant factors that you do _not_ want to correct for.
+        - name: "--obs_continuous_covariate"
+          type: string
+          required: false
+          multiple: true
+          description: |
+            Keys in adata.obs that correspond to continuous data. These covariates can be added in
+            addition to the batch covariate and are also treated as nuisance factors
+            (i.e., the model tries to minimize their effects on the latent space). Thus, these should not be
+            used for biologically-relevant factors that you do _not_ want to correct for.
     - name: Outputs
       arguments:
         - name: "--output"

--- a/src/integrate/scvi/script.py
+++ b/src/integrate/scvi/script.py
@@ -71,7 +71,11 @@ def main():
     scvi.model.SCVI.setup_anndata(
         adata,
         batch_key=par['obs_batch'],
-        layer=par['input_layer']
+        layer=par['input_layer'],
+        labels_key=par['obs_labels'],
+        size_factor_key=par['obs_size_factor'],
+        categorical_covariate_keys=par['obs_categorical_covariate'],
+        continuous_covariate_keys=par['obs_continuous_covariate'],
     )
 
     # Set up the model


### PR DESCRIPTION
## Changelog

Add `--obs_labels`, `--obs_size_factor`, `--obs_categorical_covariate`, `--obs_continuous_covariate` arguments to scvi component

## Issue ticket number and link
Closes #363 (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!