### PR TITLE
cellxgene_census: replace singlecpu label with midcpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# openpipelines 0.10.2
+
+## MINOR CHANGES
+
+* `query/cellxgene_census`: replaced label `singlecpu` with label `midcpu`.
+
 # openpipelines 0.10.1
 
 ## MINOR CHANGES

--- a/src/query/cellxgene_census/config.vsh.yaml
+++ b/src/query/cellxgene_census/config.vsh.yaml
@@ -91,4 +91,4 @@ platforms:
           - viashpy
   - type: nextflow
     directives:
-      label: [highmem, singlecpu]
+      label: [highmem, midcpu]


### PR DESCRIPTION
## Changelog

cellxgene_census: replace singlecpu label with midcpu

## Issue ticket number and link
Closes #555  (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!