### PR TITLE
Cellxgene_census: avoid creating MuData object in memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# openpipelines 0.10.2
+
+## MINOR CHANGES
+
+* `query/cellxgene_census`: avoid creating MuData object in memory by writing the modality directly to disk.
+
 # openpipelines 0.10.1
 
 ## MINOR CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-* `query/cellxgene_census`: avoid creating MuData object in memory by writing the modality directly to disk.
+* `query/cellxgene_census`: avoid creating MuData object in memory by writing the modality directly to disk (PR #558).
 
 # openpipelines 0.10.1
 

--- a/src/query/cellxgene_census/script.py
+++ b/src/query/cellxgene_census/script.py
@@ -145,7 +145,7 @@ def main():
             par["min_cells_filter_columns"]
             )
         
-    query_data.var_names =query_data.var["feature_id"]
+    query_data.var_names = query_data.var["feature_id"]
     query_data.var["gene_symbol"] = query_data.var["feature_name"]
 
     # Create empty mudata file

--- a/src/query/cellxgene_census/script.py
+++ b/src/query/cellxgene_census/script.py
@@ -2,6 +2,7 @@ import sys
 import os
 import cellxgene_census
 import mudata as mu
+import anndata as ad
 
 ## VIASH START
 par = {
@@ -143,19 +144,20 @@ def main():
             par["cells_filter_columns"],
             par["min_cells_filter_columns"]
             )
+        
+    query_data.var_names =query_data.var["feature_id"]
+    query_data.var["gene_symbol"] = query_data.var["feature_name"]
 
-    mdata = mu.MuData(
-        {par["modality"]: query_data}
-        )
+    # Create empty mudata file
+    mdata = mu.MuData({par["modality"]: ad.AnnData()})
     
-    mdata["rna"].var_names = mdata["rna"].var["feature_id"]
-    mdata["rna"].var["gene_symbol"] = mdata["rna"].var["feature_name"]
-
     write_mudata(
         mdata,
         par["output"],
         par["output_compression"]
         )
+
+    mu.write_h5ad(par["output"], data=query_data, mod=par["modality"])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Changelog

Cellxgene_census: avoid creating MuData object in memory.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!