### PR TITLE
Fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * `convert/from_bdrhap_to_h5mu`: Avoid `TypeError: Can't implicitly convert non-string objects to strings` by using categorical dtypes when a string column contains NA values (PR #563).
 
-* `qc/calculate_qc_metrics`: fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found.
+* `qc/calculate_qc_metrics`: fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found (PR #564).
 
 ## MINOR CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * `convert/from_bdrhap_to_h5mu`: Avoid `TypeError: Can't implicitly convert non-string objects to strings` by using categorical dtypes when a string column contains NA values (PR #563).
 
+* `qc/calculate_qc_metrics`: fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found.
+
 ## MINOR CHANGES
 
 * `mapping/bd_rhapsody`: pin pandas version to <2 (PR #563). 

--- a/src/qc/calculate_qc_metrics/script.py
+++ b/src/qc/calculate_qc_metrics/script.py
@@ -79,7 +79,7 @@ def main():
                 else:
                     qc_column = qc_column.fillna(par['var_qc_metrics_fill_na_value'], inplace=False)
             qc_column = qc_column.values
-            if not set(np.unique(qc_column)) == set((True, False)):
+            if set(np.unique(qc_column)) - {True, False}:
                 raise ValueError(f"Column {qc_metric} in .var for modality {par['modality']} "
                                  f"must only contain boolean values")
             


### PR DESCRIPTION
Fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found.

## Changelog

Fix calculating mitochondrial gene related QC metrics when only or no mitochondrial genes were found.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!