### PR TITLE
Bump viash to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## BREAKING CHANGES
 
-This project now uses viash version 0.8.0 to build components and workflows. Moving to project involved the following changes:
+This project now uses viash version 0.8.0 to build components and workflows. Moving to 0.8.0 involved the following changes:
 
 * Bump viash version to 0.8.0 (PR #598) in the project configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# openpipelines 0.13.0
+
+## BREAKING CHANGES
+
+This project now uses viash version 0.8.0 to build components and workflows. Moving to project involved the following changes:
+
+* Bump viash version to 0.8.0 (PR #598) in the project configuration.
+
+* The `concat` component had been deprecated and will be removed in a future release. It's functionality has been copied to the `concatenate_h5mu` component because the name is in conflict with the `concat` operator from nextflow (PR #598).
+
+* All pipelines no longer use the anonymous workflow. Instead, these workflows were given a name which was added to the viash config as the entrypoint to the pipeline (PR #598).
+
 # openpipelines 0.12.0
 
 ## BREAKING CHANGES

--- a/_viash.yaml
+++ b/_viash.yaml
@@ -1,4 +1,4 @@
-viash_version: 0.7.5
+viash_version: 0.8.0
 
 source: src
 target: target

--- a/src/dataflow/concat/config.vsh.yaml
+++ b/src/dataflow/concat/config.vsh.yaml
@@ -1,6 +1,7 @@
 functionality:
   name: concat
   namespace: "dataflow"
+  status: deprecated
   description: |
     Concatenates several uni-modal samples in .h5mu files into a single file.
   authors:

--- a/src/dataflow/concatenate_h5mu/config.vsh.yaml
+++ b/src/dataflow/concatenate_h5mu/config.vsh.yaml
@@ -1,0 +1,82 @@
+functionality:
+  name: concatenate_h5mu
+  namespace: "dataflow"
+  description: |
+    Concatenates several uni-modal samples in .h5mu files into a single file.
+  authors:
+    - __merge__: /src/authors/dries_schaumont.yaml
+      roles: [ maintainer ]
+  arguments:
+    - name: "--input"
+      alternatives: ["-i"]
+      type: file
+      multiple: true
+      multiple_sep: ','
+      description: Paths to the different samples to be concatenated.
+      required: true
+      example: sample_paths
+    - name: "--input_id"
+      type: string
+      multiple: true
+      multiple_sep: ','
+      description: |
+        Names of the different samples that have to be concatenated.  Must be specified when using '--mode move'.
+        In this case, the ids will be used for the columns names of the dataframes registring the conflicts.
+        If specified, must be of same length as `--input`.
+      required: false
+    - name: "--output"
+      alternatives: ["-o"]
+      type: file
+      direction: output
+      example: "output.h5mu"
+    - name: "--output_compression"
+      type: string
+      description: The compression format to be used on the output h5mu object.
+      choices: ["gzip", "lzf"]
+      required: false
+      example: "gzip"
+    - name: "--obs_sample_name"
+      type: string
+      description: Name of the .obs key under which to add the sample names.
+      default: "sample_id"
+    - name: "--other_axis_mode"
+      type: string
+      choices: [same, unique, first, only, concat, move]
+      default: move
+      description: |
+        How to handle the merging of other axis (var, obs, ...).
+
+         - None: keep no data
+         - same: only keep elements of the matrices which are the same in each of the samples
+         - unique: only keep elements for which there is only 1 possible value (1 value that can occur in multiple samples)
+         - first: keep the annotation from the first sample
+         - only: keep elements that show up in only one of the objects (1 unique element in only 1 sample)
+         - move: identical to 'same', but moving the conflicting values to .varm or .obsm
+  resources:
+    - type: python_script
+      path: script.py
+    - path: /src/utils/setup_logger.py
+    # - path: /src/utils/compress_h5mu.py
+  test_resources:
+    - type: python_script
+      path: test.py
+    - path: /resources_test/concat_test_data/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix_subset_unique_obs.h5mu
+    - path: /resources_test/concat_test_data/human_brain_3k_filtered_feature_bc_matrix_subset_unique_obs.h5mu
+platforms:
+  - type: docker
+    image: python:3.10-slim
+    setup:
+      - type: apt
+        packages: 
+          - procps
+      - type: python
+        __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
+        packages:
+          - pandas~=2.1.1
+    test_setup:
+      - type: python
+        __merge__: [ /src/base/requirements/viashpy.yaml, .]
+  - type: native
+  - type: nextflow
+    directives:
+      label: [midcpu, highmem]

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+import sys
+import anndata
+import mudata as mu
+import pandas as pd
+import numpy as np
+from collections.abc import Iterable
+from multiprocessing import Pool
+from pathlib import Path
+from h5py import File as H5File
+from typing import Literal
+import shutil
+
+### VIASH START
+par = {
+    "input": ["resources_test/concat_test_data/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix_subset_unique_obs.h5mu",
+              "resources_test/concat_test_data/human_brain_3k_filtered_feature_bc_matrix_subset_unique_obs.h5mu"],
+    "output": "foo.h5mu",
+    "input_id": ["mouse", "human"],
+    "other_axis_mode": "move",
+    "output_compression": "gzip"
+}
+meta = {
+    "cpus": 10,
+    "resources_dir": "resources_test/"
+}
+### VIASH END
+
+sys.path.append(meta["resources_dir"])
+
+# START TEMPORARY WORKAROUND compress_h5mu
+# reason: resources aren't available when using Nextflow fusion
+
+# from compress_h5mu import compress_h5mu
+from h5py import Group, Dataset
+from typing import Union
+from functools import partial
+
+def compress_h5mu(input_path: Union[str, Path], 
+                output_path: Union[str, Path], 
+                compression: Union[Literal['gzip'], Literal['lzf']]):
+    input_path, output_path = str(input_path), str(output_path)
+
+    def copy_attributes(in_object, out_object):
+        for key, value in in_object.attrs.items():
+            out_object.attrs[key] = value
+
+    def visit_path(output_h5: H5File,
+                   compression: Union[Literal['gzip'], Literal['lzf']], 
+                   name: str, object: Union[Group, Dataset]):
+            if isinstance(object, Group):
+                new_group = output_h5.create_group(name)
+                copy_attributes(object, new_group)
+            elif isinstance(object, Dataset):
+                # Compression only works for non-scalar Dataset objects
+                # Scalar objects dont have a shape defined
+                if not object.compression and object.shape not in [None, ()]: 
+                    new_dataset = output_h5.create_dataset(name, data=object, compression=compression)
+                    copy_attributes(object, new_dataset)
+                else:
+                    output_h5.copy(object, name)
+            else:
+                raise NotImplementedError(f"Could not copy element {name}, "
+                                          f"type has not been implemented yet: {type(object)}")
+
+    with H5File(input_path, 'r') as input_h5, H5File(output_path, 'w', userblock_size=512) as output_h5:
+        copy_attributes(input_h5, output_h5)
+        input_h5.visititems(partial(visit_path, output_h5, compression))
+
+    with open(input_path, "rb") as input_bytes:
+        # Mudata puts metadata like this in the first 512 bytes:
+        # MuData (format-version=0.1.0;creator=muon;creator-version=0.2.0)
+        # See mudata/_core/io.py, read_h5mu() function
+        starting_metadata = input_bytes.read(100)
+        # The metadata is padded with extra null bytes up until 512 bytes
+        truncate_location = starting_metadata.find(b"\x00")
+        starting_metadata = starting_metadata[:truncate_location]
+    with open(output_path, "br+") as f:
+        nbytes = f.write(starting_metadata)
+        f.write(b"\0" * (512 - nbytes))
+# END TEMPORARY WORKAROUND compress_h5mu
+
+# START TEMPORARY WORKAROUND setup_logger
+# from setup_logger import setup_logger
+def setup_logger():
+    import logging
+    from sys import stdout
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    console_handler = logging.StreamHandler(stdout)
+    logFormatter = logging.Formatter("%(asctime)s %(levelname)-8s %(message)s")
+    console_handler.setFormatter(logFormatter)
+    logger.addHandler(console_handler)
+
+    return logger
+# END TEMPORARY WORKAROUND setup_logger
+logger = setup_logger()
+
+def indexes_unique(indices: Iterable[pd.Index]) -> bool:
+    combined_indices = indices[0].append(indices[1:])
+    return combined_indices.is_unique
+
+def check_observations_unique(samples: Iterable[anndata.AnnData]) -> None:
+    observation_ids = [sample.obs.index for sample in samples]
+    if not indexes_unique(observation_ids):
+        raise ValueError("Observations are not unique across samples.")
+
+
+def nunique(row):
+    unique = pd.unique(row)
+    unique_without_na = pd.core.dtypes.missing.remove_na_arraylike(unique)
+    return len(unique_without_na) > 1
+
+def any_row_contains_duplicate_values(n_processes: int, frame: pd.DataFrame) -> bool:
+    """
+    Check if any row contains duplicate values, that are not NA.
+    """
+    numpy_array = frame.to_numpy()
+    with Pool(n_processes) as pool:
+        is_duplicated = pool.map(nunique, iter(numpy_array))
+    return any(is_duplicated)
+
+def concatenate_matrices(n_processes: int, input_ids: tuple[str], matrices: Iterable[pd.DataFrame]) \
+    -> tuple[dict[str, pd.DataFrame], pd.DataFrame | None, dict[str, pd.core.dtypes.dtypes.Dtype]]:
+    """
+    Merge matrices by combining columns that have the same name.
+    Columns that contain conflicting values (e.i. the columns have different values),
+    are not merged, but instead moved to a new dataframe.
+    """
+    column_names = set(column_name for var in matrices for column_name in var)
+    logger.debug('Trying to concatenate columns: %s.', ",".join(column_names))
+    if not column_names:
+        return {}, None
+    conflicts, concatenated_matrix = \
+        split_conflicts_and_concatenated_columns(n_processes,
+                                                 input_ids,
+                                                 matrices,
+                                                 column_names)
+    concatenated_matrix = cast_to_writeable_dtype(concatenated_matrix)
+    conflicts = {conflict_name: cast_to_writeable_dtype(conflict_df) 
+                 for conflict_name, conflict_df in conflicts.items()}
+    return conflicts, concatenated_matrix
+
+def get_first_non_na_value_vector(df):
+    numpy_arr = df.to_numpy()
+    n_rows, n_cols = numpy_arr.shape
+    col_index = pd.isna(numpy_arr).argmin(axis=1)
+    flat_index = n_cols * np.arange(n_rows) + col_index
+    return pd.Series(numpy_arr.ravel()[flat_index], index=df.index, name=df.columns[0])
+
+def split_conflicts_and_concatenated_columns(n_processes: int,
+                                             input_ids: tuple[str],
+                                             matrices: Iterable[pd.DataFrame],
+                                             column_names: Iterable[str]) -> \
+                                            tuple[dict[str, pd.DataFrame], pd.DataFrame]:
+    """
+    Retrieve columns with the same name from a list of dataframes which are
+    identical across all the frames (ignoring NA values).
+    Columns which are not the same are regarded as 'conflicts',
+    which are stored in seperate dataframes, one per columns
+    with the same name that store conflicting values.
+    """
+    conflicts = {}
+    concatenated_matrix = []
+    for column_name in column_names:
+        columns = [var[column_name] for var in matrices if column_name in var]
+        assert columns, "Some columns should have been found."
+        concatenated_columns = pd.concat(columns, axis=1, join="outer")
+        if any_row_contains_duplicate_values(n_processes, concatenated_columns):
+            concatenated_columns.columns = input_ids
+            conflicts[f'conflict_{column_name}'] = concatenated_columns
+        else:
+            unique_values = get_first_non_na_value_vector(concatenated_columns)
+            # concatenated_columns.fillna(method='bfill', axis=1).iloc[:, 0]
+            concatenated_matrix.append(unique_values)
+    if concatenated_matrix:
+        concatenated_matrix = pd.concat(concatenated_matrix, join="outer", axis=1)
+    else:
+        concatenated_matrix = pd.DataFrame()
+
+    return conflicts, concatenated_matrix
+
+def cast_to_writeable_dtype(result: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast the dataframe to dtypes that can be written by mudata.
+    """    
+    # dtype inferral workfs better with np.nan
+    result = result.replace({pd.NA: np.nan})
+
+    # MuData supports nullable booleans and ints
+    # ie. `IntegerArray` and `BooleanArray`
+    result = result.convert_dtypes(infer_objects=True,
+                                   convert_integer=True,
+                                   convert_string=False,
+                                   convert_boolean=True,
+                                   convert_floating=False)
+    
+    # Convert leftover 'object' columns to string
+    object_cols = result.select_dtypes(include='object').columns.values
+    for obj_col in object_cols:
+        result[obj_col].astype(str).astype('category')
+    return result
+
+def split_conflicts_modalities(n_processes: int, input_ids: tuple[str], samples: Iterable[anndata.AnnData], output: anndata.AnnData) \
+        -> anndata.AnnData:
+    """
+    Merge .var and .obs matrices of the anndata objects. Columns are merged
+    when the values (excl NA) are the same in each of the matrices.
+    Conflicting columns are moved to a separate dataframe (one dataframe for each column,
+    containing all the corresponding column from each sample).
+    """
+    matrices_to_parse = ("var", "obs")
+    for matrix_name in matrices_to_parse:
+        matrices = [getattr(sample, matrix_name) for sample in samples]
+        conflicts, concatenated_matrix = concatenate_matrices(n_processes, input_ids, matrices)
+        
+        # Write the conflicts to the output
+        matrix_index = getattr(output, matrix_name).index
+        for conflict_name, conflict_data in conflicts.items():
+            getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data.reindex(matrix_index)
+
+        # Set other annotation matrices in the output
+        setattr(output, matrix_name, pd.DataFrame() if concatenated_matrix is None else concatenated_matrix)
+
+    return output
+
+
+def concatenate_modality(n_processes: int, mod: str, input_files: Iterable[str | Path], 
+                         other_axis_mode: str, input_ids: tuple[str]) -> anndata.AnnData:
+    
+    concat_modes = {
+        "move": None,
+    }
+    other_axis_mode_to_apply = concat_modes.get(other_axis_mode, other_axis_mode)
+
+    mod_data = []
+    for input_file in input_files:
+        try:
+            mod_data.append(mu.read_h5ad(input_file, mod=mod))
+        except KeyError as e: # Modality does not exist for this sample, skip it
+            if f"Unable to open object '{mod}' doesn't exist" not in str(e):
+                raise e
+            pass
+    check_observations_unique(mod_data)
+
+    concatenated_data = anndata.concat(mod_data, join='outer', merge=other_axis_mode_to_apply)
+
+    if other_axis_mode == "move":
+        concatenated_data = split_conflicts_modalities(n_processes, input_ids, mod_data, concatenated_data)
+    
+    return concatenated_data
+
+def concatenate_modalities(n_processes: int, modalities: list[str], input_files: Path | str,
+                           other_axis_mode: str, output_file: Path | str,
+                           compression: Literal['gzip'] | Literal['lzf'],
+                           input_ids: tuple[str] | None = None) -> None:
+    """
+    Join the modalities together into a single multimodal sample.
+    """
+    logger.info('Concatenating samples.')
+    output_file, input_files = Path(output_file), [Path(input_file) for input_file in input_files]
+    output_file_uncompressed = output_file.with_name(output_file.stem + "_uncompressed.h5mu")
+    output_file_uncompressed.touch()
+    # Create empty mudata file
+    mdata = mu.MuData({modality: anndata.AnnData() for modality in modalities})
+    mdata.write(output_file_uncompressed, compression=compression)
+
+    for mod_name in modalities:
+        new_mod = concatenate_modality(n_processes, mod_name, 
+                                       input_files, other_axis_mode, 
+                                       input_ids)
+        logger.info("Writing out modality '%s' to '%s' with compression '%s'.",
+                    mod_name, output_file_uncompressed, compression)
+        mu.write_h5ad(output_file_uncompressed, data=new_mod, mod=mod_name)
+    
+    if compression:
+        compress_h5mu(output_file_uncompressed, output_file, compression=compression)
+        output_file_uncompressed.unlink()
+    else:
+        shutil.move(output_file_uncompressed, output_file)
+
+    logger.info("Concatenation successful.")
+
+def main() -> None:
+    # Get a list of all possible modalities
+    mods = set()
+    for path in par["input"]:
+        try:
+            with H5File(path, 'r') as f_root:
+                mods = mods | set(f_root["mod"].keys())
+        except OSError:
+            raise OSError(f"Failed to load {path}. Is it a valid h5 file?")
+
+    input_ids = None
+    if par["input_id"]:
+        input_ids: tuple[str] = tuple(i.strip() for i in par["input_id"])
+        if len(input_ids) != len(par["input"]):
+            raise ValueError("The number of sample names must match the number of sample files.")
+
+        if len(set(input_ids)) != len(input_ids):
+            raise ValueError("The sample names should be unique.")
+
+    logger.info("\nConcatenating data from paths:\n\t%s",
+                "\n\t".join(par["input"]))
+
+    if par["other_axis_mode"] == "move" and not input_ids:
+        raise ValueError("--mode 'move' requires --input_ids.")
+
+    n_processes = meta["cpus"] if meta["cpus"] else 1
+    concatenate_modalities(n_processes,
+                           list(mods),
+                           par["input"],
+                           par["other_axis_mode"],
+                           par["output"],
+                           par["output_compression"],
+                           input_ids=input_ids)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -1,0 +1,350 @@
+import mudata as md
+import subprocess
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import pytest
+import re
+import sys
+
+## VIASH START
+meta = {
+    'executable': './target/docker/dataflow/concatenate_h5mu/concatenate_h5mu',
+    'resources_dir': './resources_test/concat_test_data/',
+    'cpus': 2,
+    'config': './src/dataflow/concatenate_h5mu/config.vsh.yaml'
+}
+## VIASH END
+
+meta['cpus'] = 1 if not meta['cpus'] else meta['cpus']
+
+# Note: the .var for these samples have no overlap, so there are no conflicting annotations
+# for the features that need to be handled by the concat component.
+# The tests below that specifically test the concatenation of conflicting data need to introduce
+# the conflict.
+input_sample1_file = f"{meta['resources_dir']}/e18_mouse_brain_fresh_5k_filtered_feature_bc_matrix_subset_unique_obs.h5mu"
+input_sample2_file = f"{meta['resources_dir']}/human_brain_3k_filtered_feature_bc_matrix_subset_unique_obs.h5mu"
+
+@pytest.fixture
+def mudata_without_genome(tmp_path, request):
+    mudatas_to_change, modalities = request.param
+    result = []
+    for mudata_to_change in mudatas_to_change:
+        new_mudata = md.read(mudata_to_change)
+        for mod in modalities:
+            new_mudata.mod[mod].var.drop('genome', axis=1, inplace=True)
+        # Note: when a column is present in the feature annotation for one
+        # modality (MuData.mod[...].var) but not for another other, then the global
+        # var (MuData.var) gets a new column 'mod_name:column_name'
+        # (here atac:genome) next to the old 'column_name' (here just 'genome')
+        new_mudata.update_var()
+        new_mudata.var.drop('genome', axis=1, inplace=True)
+        new_path = tmp_path / Path(mudata_to_change).name
+        new_mudata.write(new_path, compression="gzip")
+        result.append(new_path)
+    return result
+
+@pytest.fixture
+def mudata_copy_with_unique_obs(request):
+    mudata_to_copy = request.param
+    mudata_contents = md.read(mudata_to_copy)
+    copied_contents = mudata_contents.copy()
+    for mod_data in copied_contents.mod.values():
+        mod_data.obs.index = "make_unique_" + mod_data.obs.index
+    return mudata_contents, copied_contents
+
+@pytest.fixture
+def exta_var_column_value():
+    return "bar"
+
+@pytest.fixture
+def copied_mudata_with_extra_var_column(tmp_path, mudata_copy_with_unique_obs, exta_var_column_value):
+    [original_mudata, copied_mudata] = mudata_copy_with_unique_obs
+    original_mudata.mod['rna'].var['test'] = np.nan
+    original_mudata.mod['atac'].var['test'] = exta_var_column_value
+    original_mudata.update_var()
+    copied_mudata.mod['rna'].var['test'] = np.nan
+    copied_mudata.mod['atac'].var['test'] = np.nan
+    original_mudata.var = original_mudata.var.convert_dtypes(infer_objects=True,
+                                                             convert_integer=True,
+                                                             convert_string=False,
+                                                             convert_boolean=True,
+                                                             convert_floating=False)
+    
+    copied_mudata.update_var()
+    copied_mudata.update_obs()
+    original_mudata_path = tmp_path / "original.h5mu"
+    copy_mudata_path = tmp_path / "modified_copy.h5mu"
+    original_mudata.write(str(original_mudata_path), compression="gzip")
+    copied_mudata.write(str(copy_mudata_path), compression="gzip")
+    return original_mudata_path, copy_mudata_path
+
+def test_concatenate_samples_with_same_observation_ids_raises(run_component):
+    """
+    Test how concat handles overlapping observation IDs.
+    This should raise.
+    """
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component([
+                "--input_id", "mouse,mouse2",
+                "--input", input_sample1_file,
+                "--input", input_sample1_file,
+                "--output", "concat.h5mu",
+                "--other_axis_mode", "move",
+                "--output_compression", "gzip"
+                ])
+        assert "ValueError: Observations are not unique across samples." in \
+            err.value.stdout.decode('utf-8')
+
+@pytest.mark.parametrize("mudata_without_genome",
+                          [([input_sample1_file], ["rna", "atac"])],
+                          indirect=["mudata_without_genome"])
+def test_concat_different_var_columns_per_sample(run_component, mudata_without_genome):
+    """
+    Test what happens when concatenating samples with differing auxiliary
+    (like in .var) columns (present in 1 sample, absent in other).
+    When concatenating the samples, all columns should be present in the
+    resulting object, filling the values from samples with the missing
+    column with NA.
+    """
+    [sample1_without_genome,] = mudata_without_genome
+    run_component([
+            "--input_id", "mouse,human",
+            "--input", sample1_without_genome,
+            "--input", input_sample2_file,
+            "--output", "concat.h5mu",
+            "--other_axis_mode", "move"
+            ])
+
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+
+    data_sample1 = md.read(str(sample1_without_genome))
+    data_sample2 = md.read(input_sample2_file)
+
+    assert 'genome' not in data_sample1.var_keys()
+    assert concatenated_data.n_vars == data_sample1.var.index.union(data_sample2.var.index).size
+
+    # Check if all features are present
+    for mod_name in ("rna", "atac"):
+        concatenated_mod = concatenated_data.mod[mod_name]
+        original_var_keys = set(data_sample1.mod[mod_name].var.keys().tolist() +
+                                data_sample2.mod[mod_name].var.keys().tolist())
+
+        assert original_var_keys == \
+                            set(column_name.removeprefix('conflict_')
+                                for column_name in concatenated_mod.varm.keys()) | \
+                            set(concatenated_mod.var.columns.tolist())
+    # Value from sample1 should have NA
+    assert pd.isna(concatenated_data.var.loc['ENSMUSG00000051951']['genome']) is True
+
+    # Value originating from sample 2 should be the same in concatenated object.
+    # Here, they are the same because we concatenate 2 samples so
+    # there is only 1 unique value
+    assert concatenated_data.var.loc['GL000195.1:71201-71602']['genome'] == \
+            data_sample2.var.loc['GL000195.1:71201-71602']['genome']
+
+
+@pytest.mark.parametrize("mudata_without_genome",
+                          [([input_sample1_file, input_sample2_file], ["rna"])],
+                          indirect=["mudata_without_genome"])
+def test_concat_different_columns_per_modality(run_component, mudata_without_genome):
+    """
+    Test what happens when concatenating samples that have auxiliary columns
+    that differ between the modalities, but the difference is the same in all samples.
+    """
+    sample1_without_genome, sample2_without_genome = mudata_without_genome
+
+    run_component([
+            "--input_id", "mouse,human",
+            "--input", sample1_without_genome,
+            "--input", sample2_without_genome,
+            "--output", "concat.h5mu",
+            "--other_axis_mode", "move"
+            ])
+
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+
+    data_sample1 = md.read(str(sample1_without_genome))
+    data_sample2 = md.read(str(sample2_without_genome))
+
+    # Check if all features are present
+    assert concatenated_data.n_vars == \
+            data_sample1.var.index.union(data_sample2.var.index).size
+
+    for mod_name in ("rna", "atac"):
+        concatenated_mod = concatenated_data.mod[mod_name]
+        original_var_keys = set(data_sample1.mod[mod_name].var.keys().tolist() +
+                                data_sample2.mod[mod_name].var.keys().tolist())
+
+        assert original_var_keys == \
+                            set(column_name.removeprefix('conflict_')
+                                for column_name in concatenated_mod.varm.keys()) | \
+                            set(concatenated_mod.var.columns.tolist())
+
+    # Check if 'interval' stays removed from modality
+    assert 'genome' not in concatenated_data.mod['rna'].var.columns
+
+    # Value from sample1 should have NA
+    # ENSMUSG00000051951 is first entry from data_sample1.mod['rna'].var.head()
+    assert pd.isna(concatenated_data.var.loc['ENSMUSG00000051951']['atac:genome']) is True
+    # chr1:3094399-3095523 is the first entry from data_sample1.mod['atac'].var.head()
+    assert concatenated_data.var.loc['chr1:3094399-3095523']['atac:genome'] == 'mm10'
+    assert concatenated_data.mod['atac'].var.loc['chr1:3094399-3095523']['genome'] == 'mm10'
+
+@pytest.mark.parametrize("mudata_without_genome",
+                          [([input_sample1_file], ["rna"])],
+                          indirect=["mudata_without_genome"])
+def test_concat_different_columns_per_modality_and_per_sample(run_component, mudata_without_genome):
+    """
+    Test what happens when concatenating samples that have auxiliary columns
+    that differ between the modalities and also between samples
+    """
+
+    [sample_1_without_genome, ] = mudata_without_genome
+    run_component([
+        "--input_id", "mouse,human",
+        "--input", sample_1_without_genome,
+        "--input", input_sample2_file,
+        "--output", "concat.h5mu",
+        "--other_axis_mode", "move"
+        ])
+
+    assert Path("concat.h5mu").is_file() == True
+    concatenated_data = md.read("concat.h5mu")
+
+    data_sample1 = md.read(str(sample_1_without_genome))
+    data_sample2 = md.read(input_sample2_file)
+
+    # Check if all features are present
+    assert concatenated_data.n_vars == \
+            data_sample1.var.index.union(data_sample2.var.index).size
+
+    # Check if all features are present
+    for mod_name in ("rna", "atac"):
+        concatenated_mod = concatenated_data.mod[mod_name]
+        original_var_keys = set(data_sample1.mod[mod_name].var.keys().tolist() +
+                                data_sample2.mod[mod_name].var.keys().tolist())
+
+        assert original_var_keys == \
+                            set(column_name.removeprefix('conflict_')
+                                for column_name in concatenated_mod.varm.keys()) | \
+                            set(concatenated_mod.var.columns.tolist())
+
+
+    # Check if 'interval' is included in RNA modality
+    assert 'genome' in concatenated_data.mod['rna'].var.columns
+
+    # Value from sample1 should have NA
+    # ENSMUSG00000051951 is first entry from data_sample1.mod['rna'].var.head()
+    assert pd.isna(concatenated_data.var.loc['ENSMUSG00000051951']['genome'])
+    # chr1:3094399-3095523 is the first entry from data_sample1.mod['atac'].var.head()
+    assert concatenated_data.var.loc['chr1:3094399-3095523']['genome'] == 'mm10'
+    assert concatenated_data.mod['atac'].var.loc['chr1:3094399-3095523']['genome'] == 'mm10'
+
+@pytest.mark.parametrize("exta_var_column_value,expected", [("bar", "bar"), (True, True), (0.1, 0.1), (np.nan, pd.NA)])
+@pytest.mark.parametrize("mudata_copy_with_unique_obs",
+                          [input_sample1_file],
+                          indirect=["mudata_copy_with_unique_obs"])
+def test_concat_remove_na(run_component, copied_mudata_with_extra_var_column, expected):
+    """
+    Test concatenation of samples where the column from one sample contains NA values
+    NA values should be removed from the concatenated result
+    """
+    tempfile_input1, tempfile_input2 = copied_mudata_with_extra_var_column
+    run_component([
+        "--input_id", "mouse,human",
+        "--input", tempfile_input1,
+        "--input", tempfile_input2,
+        "--output", "concat.h5mu",
+        "--other_axis_mode", "move"
+        ])
+
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+    
+    if not pd.isna(expected):
+        assert concatenated_data.var.loc['chr1:3094399-3095523']['test'] == expected
+        assert concatenated_data.mod['atac'].var.loc['chr1:3094399-3095523']['test'] == expected
+    else:
+        assert pd.isna(concatenated_data.var.loc['chr1:3094399-3095523']['test'])
+        assert pd.isna(concatenated_data.mod['atac'].var.loc['chr1:3094399-3095523']['test'])
+
+    assert pd.isna(concatenated_data.var.loc['ENSMUSG00000051951']['test']) is True
+    assert pd.isna(concatenated_data.mod['rna'].var.loc['ENSMUSG00000051951']['test']) is True
+
+
+def test_mode_move(run_component, tmp_path):
+    tempfile_input1 = tmp_path / "input1.h5mu"
+    tempfile_input2 = tmp_path / "input2.h5mu"
+    input1 = md.read(input_sample1_file)
+    input2 = md.read(input_sample2_file)
+    # Create conflict
+    var_index_values = input1.var.index.to_numpy()
+    var_index_values[0] = input2.var.index[0]
+    input1.var.index = var_index_values
+    var_index_values = input1.mod['rna'].var.index.to_numpy()
+    var_index_values[0] = input2.mod['rna'].var.index.to_numpy()[0]
+    input1.mod['rna'].var.index = var_index_values
+    input1.write(tempfile_input1.name)
+    input2.write(tempfile_input2.name)
+    run_component([
+        "--input_id", "mouse,human",
+        "--input", tempfile_input1.name,
+        "--input", tempfile_input2.name,
+        "--output", "concat.h5mu",
+        "--other_axis_mode", "move"
+        ])
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+
+    # Check if observations from all of the samples are present
+    assert (concatenated_data.n_obs ==  input1.n_obs + input2.n_obs)
+
+    # Check if all modalities are present
+    sample1_mods, sample2_mods = set(input1.mod.keys()), set(input2.mod.keys())
+    concatentated_mods = set(concatenated_data.mod.keys())
+    assert (sample1_mods | sample2_mods) == concatentated_mods
+
+    varm_check = {
+        "rna": ({"conflict_gene_symbol": ("mouse", "human"),
+                 "conflict_genome": ("mouse", "human")}),
+        "atac": {}
+    }
+
+    # Check if all features are present
+    for mod_name in ("rna", "atac"):
+        concatenated_mod = concatenated_data.mod[mod_name]
+        original_var_keys = set(input1.mod[mod_name].var.keys().tolist() +
+                                    input2.mod[mod_name].var.keys().tolist())
+
+        assert original_var_keys == \
+                            set(column_name.removeprefix('conflict_')
+                                for column_name in concatenated_mod.varm.keys()) | \
+                            set(concatenated_mod.var.columns.tolist())
+
+        varm_expected = varm_check[mod_name]
+        assert list(concatenated_mod.varm.keys()) == list(varm_expected.keys())
+        for varm_key, expected_columns in varm_expected.items():
+            assert tuple(concatenated_mod.varm[varm_key].columns) == expected_columns
+        if not varm_expected:
+            assert concatenated_mod.varm == {}
+        assert concatenated_mod.obsm == {}
+
+def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
+    empty_file = tmp_path / "empty.h5mu"
+    empty_file.touch()
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component([
+                "--input_id", "mouse,empty",
+                "--input", input_sample1_file,
+                "--input", empty_file,
+                "--output", "concat.h5mu",
+                "--other_axis_mode", "move"
+                ])
+        assert re.search(rf"OSError: Failed to load .*{str(empty_file)}\. Is it a valid h5 file?",
+            err.value.stdout.decode('utf-8'))
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/workflows/ingestion/bd_rhapsody/config.vsh.yaml
+++ b/workflows/ingestion/bd_rhapsody/config.vsh.yaml
@@ -147,6 +147,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: bd_rhapsody_entrypoint
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/bd_rhapsody/main.nf
+++ b/workflows/ingestion/bd_rhapsody/main.nf
@@ -10,7 +10,7 @@ include { readConfig; channelFromParams; preprocessInputs; helpMessage } from wo
 
 config = readConfig("$workflowDir/ingestion/bd_rhapsody/config.vsh.yaml")
 
-workflow {
+workflow bd_rhapsody_entrypoint {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/ingestion/cellranger_mapping/config.vsh.yaml
+++ b/workflows/ingestion/cellranger_mapping/config.vsh.yaml
@@ -97,6 +97,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: cellranger_mapping
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/cellranger_mapping/main.nf
+++ b/workflows/ingestion/cellranger_mapping/main.nf
@@ -12,7 +12,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/ingestion/cellranger_mapping/config.vsh.yaml")
 
-workflow {
+workflow cellranger_mapping {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/ingestion/cellranger_multi/config.vsh.yaml
+++ b/workflows/ingestion/cellranger_multi/config.vsh.yaml
@@ -162,6 +162,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: cellranger_multi_entrypoint
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/cellranger_multi/main.nf
+++ b/workflows/ingestion/cellranger_multi/main.nf
@@ -12,7 +12,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/ingestion/cellranger_multi/config.vsh.yaml")
 
-workflow {
+workflow cellranger_multi_entrypoint {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/ingestion/cellranger_postprocessing/config.vsh.yaml
+++ b/workflows/ingestion/cellranger_postprocessing/config.vsh.yaml
@@ -50,6 +50,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: cellranger_postprocessing
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/conversion/config.vsh.yaml
+++ b/workflows/ingestion/conversion/config.vsh.yaml
@@ -19,8 +19,6 @@ functionality:
           alternatives: [-i]
           description: Path to the sample.
           required: true
-          multiple: true
-          multiple_sep: ';'
           example: input.h5mu
           type: file
         - name: "--input_type"
@@ -48,6 +46,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: conversion
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/conversion/main.nf
+++ b/workflows/ingestion/conversion/main.nf
@@ -12,7 +12,7 @@ include { passthroughMap as pmap } from workflowDir + "/utils/DataflowHelper.nf"
 
 config = readConfig("$workflowDir/ingestion/conversion/config.vsh.yaml")
 
-workflow {
+workflow conversion {
   helpMessage(config)
 
   channelFromParams(params, config)
@@ -26,6 +26,7 @@ workflow run_wf {
     main:
         preprocessed_ch = input_ch
           | preprocessInputs("config": config)
+          | view{"HERE: $it"}
         commonOptions = [
             auto: [ publish: true ],
             args: [ output_compression: "gzip" ]

--- a/workflows/ingestion/demux/config.vsh.yaml
+++ b/workflows/ingestion/demux/config.vsh.yaml
@@ -46,6 +46,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: demux
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/demux/main.nf
+++ b/workflows/ingestion/demux/main.nf
@@ -14,7 +14,7 @@ include { passthroughMap as pmap } from workflowDir + "/utils/DataflowHelper.nf"
 
 config = readConfig("$workflowDir/ingestion/demux/config.vsh.yaml")
 
-workflow {
+workflow demux {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/ingestion/make_reference/config.vsh.yaml
+++ b/workflows/ingestion/make_reference/config.vsh.yaml
@@ -72,6 +72,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: make_reference_entrypoint
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/ingestion/make_reference/main.nf
+++ b/workflows/ingestion/make_reference/main.nf
@@ -13,7 +13,7 @@ include { setWorkflowArguments; getWorkflowArguments } from workflowDir + "/util
 
 config = readConfig("$workflowDir/ingestion/make_reference/config.vsh.yaml")
 
-workflow {
+workflow make_reference_entrypoint {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/full_pipeline/config.vsh.yaml
+++ b/workflows/multiomics/full_pipeline/config.vsh.yaml
@@ -180,6 +180,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: full_pipeline
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/full_pipeline/main.nf
+++ b/workflows/multiomics/full_pipeline/main.nf
@@ -5,7 +5,7 @@ targetDir = params.rootDir + "/target/nextflow"
 include { add_id } from targetDir + "/metadata/add_id/main.nf"
 include { split_modalities } from targetDir + '/dataflow/split_modalities/main.nf'
 include { merge } from targetDir + '/dataflow/merge/main.nf'
-include { concat } from targetDir + '/dataflow/concat/main.nf'
+include { concatenate_h5mu } from targetDir + '/dataflow/concatenate_h5mu/main.nf'
 include { remove_modality }  from targetDir + '/filter/remove_modality/main.nf'
 include { publish }  from targetDir + '/transfer/publish/main.nf'
 include { run_wf as rna_singlesample } from workflowDir + '/multiomics/rna_singlesample/main.nf'
@@ -20,7 +20,7 @@ include { readConfig; helpMessage; readCsv; preprocessInputs; channelFromParams 
 include {  setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap; passthroughFlatMap as pFlatMap; strictMap as smap } from workflowDir + "/utils/DataflowHelper.nf"
 config = readConfig("$workflowDir/multiomics/full_pipeline/config.vsh.yaml")
 
-workflow {
+workflow full_pipeline {
   helpMessage(config)
 
   channelFromParams(params, config)
@@ -287,10 +287,7 @@ workflow concat_workflow {
         def new_modalities = grouped_lst[4][0]
         [new_id, new_data] + new_passthrough + new_modalities
       }
-      | concat.run(
-          // The Ids have already been added in this pipeline
-          args: [ add_id_to_obs: false ]
-      )
+      | concatenate_h5mu
 
   emit:
     concat_ch

--- a/workflows/multiomics/integration/bbknn_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/bbknn_leiden/config.vsh.yaml
@@ -95,6 +95,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: bbknn_leiden
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/bbknn_leiden/main.nf
+++ b/workflows/multiomics/integration/bbknn_leiden/main.nf
@@ -13,7 +13,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/bbknn_leiden/config.vsh.yaml")
 
-workflow {
+workflow bbknn_leiden {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/integration/harmony_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/harmony_leiden/config.vsh.yaml
@@ -99,6 +99,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: harmony_leiden
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/harmony_leiden/main.nf
+++ b/workflows/multiomics/integration/harmony_leiden/main.nf
@@ -14,7 +14,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/harmony_leiden/config.vsh.yaml")
 
-workflow {
+workflow harmony_leiden {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/integration/initialize_integration/config.vsh.yaml
+++ b/workflows/multiomics/integration/initialize_integration/config.vsh.yaml
@@ -73,6 +73,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: initialize_integration
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/initialize_integration/main.nf
+++ b/workflows/multiomics/integration/initialize_integration/main.nf
@@ -12,7 +12,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/initialize_integration/config.vsh.yaml")
 
-workflow {
+workflow initialize_integration {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/integration/scanorama_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/scanorama_leiden/config.vsh.yaml
@@ -111,6 +111,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: scanorama_leiden
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/scanorama_leiden/main.nf
+++ b/workflows/multiomics/integration/scanorama_leiden/main.nf
@@ -14,7 +14,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/scanorama_leiden/config.vsh.yaml")
 
-workflow {
+workflow scanorama_leiden {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/integration/scvi_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/scvi_leiden/config.vsh.yaml
@@ -133,6 +133,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: scvi_leiden
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/scvi_leiden/main.nf
+++ b/workflows/multiomics/integration/scvi_leiden/main.nf
@@ -15,7 +15,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/scvi_leiden/config.vsh.yaml")
 
-workflow {
+workflow scvi_leiden {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/integration/totalvi_leiden/config.vsh.yaml
+++ b/workflows/multiomics/integration/totalvi_leiden/config.vsh.yaml
@@ -177,6 +177,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: totalvi_leiden
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/integration/totalvi_leiden/main.nf
+++ b/workflows/multiomics/integration/totalvi_leiden/main.nf
@@ -16,7 +16,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/integration/totalvi_leiden/config.vsh.yaml")
 
-workflow {
+workflow totalvi_leiden {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/multisample/config.vsh.yaml
+++ b/workflows/multiomics/multisample/config.vsh.yaml
@@ -77,6 +77,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: multisample
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/multisample/main.nf
+++ b/workflows/multiomics/multisample/main.nf
@@ -13,7 +13,7 @@ include { readConfig; helpMessage; readCsv; preprocessInputs; channelFromParams 
 include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap; passthroughFlatMap as pFlatMap } from workflowDir + "/utils/DataflowHelper.nf"
 config = readConfig("$workflowDir/multiomics/multisample/config.vsh.yaml")
 
-workflow {
+workflow multisample {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/prot_multisample/config.vsh.yaml
+++ b/workflows/multiomics/prot_multisample/config.vsh.yaml
@@ -54,6 +54,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: prot_multisample
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/prot_multisample/main.nf
+++ b/workflows/multiomics/prot_multisample/main.nf
@@ -4,7 +4,6 @@ workflowDir = params.rootDir + "/workflows"
 targetDir = params.rootDir + "/target/nextflow"
 
 include { clr } from targetDir + '/transform/clr/main.nf'
-include { concat } from targetDir + '/dataflow/concat/main.nf'
 include { add_id } from targetDir + '/metadata/add_id/main.nf'
 include { calculate_qc_metrics } from targetDir + '/qc/calculate_qc_metrics/main.nf'
 include { qc as prot_qc } from workflowDir + '/qc/qc/main.nf'
@@ -13,7 +12,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap; pa
 
 config = readConfig("$workflowDir/multiomics/prot_multisample/config.vsh.yaml")
 
-workflow {
+workflow prot_multisample {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/prot_singlesample/config.vsh.yaml
+++ b/workflows/multiomics/prot_singlesample/config.vsh.yaml
@@ -59,6 +59,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: prot_singlesample
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/prot_singlesample/main.nf
+++ b/workflows/multiomics/prot_singlesample/main.nf
@@ -11,7 +11,7 @@ include { qc as unfiltered_counts_qc_metrics_prot } from workflowDir + "/qc/qc/m
 
 config = readConfig("$workflowDir/multiomics/prot_singlesample/config.vsh.yaml")
 
-workflow {
+workflow prot_singlesample {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/rna_multisample/config.vsh.yaml
+++ b/workflows/multiomics/rna_multisample/config.vsh.yaml
@@ -86,6 +86,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: rna_multisample
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/rna_multisample/main.nf
+++ b/workflows/multiomics/rna_multisample/main.nf
@@ -6,7 +6,6 @@ targetDir = params.rootDir + "/target/nextflow"
 include { normalize_total } from targetDir + '/transform/normalize_total/main.nf'
 include { log1p } from targetDir + '/transform/log1p/main.nf'
 include { filter_with_hvg } from targetDir + '/filter/filter_with_hvg/main.nf'
-include { concat } from targetDir + '/dataflow/concat/main.nf'
 include { calculate_qc_metrics } from targetDir + '/qc/calculate_qc_metrics/main.nf'
 include { delete_layer } from targetDir + '/transform/delete_layer/main.nf'
 include { add_id } from targetDir + "/metadata/add_id/main.nf"
@@ -16,7 +15,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap; pa
 
 config = readConfig("$workflowDir/multiomics/rna_multisample/config.vsh.yaml")
 
-workflow {
+workflow rna_multisample {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/multiomics/rna_singlesample/config.vsh.yaml
+++ b/workflows/multiomics/rna_singlesample/config.vsh.yaml
@@ -104,6 +104,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: rna_singlesample
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/multiomics/rna_singlesample/main.nf
+++ b/workflows/multiomics/rna_singlesample/main.nf
@@ -14,7 +14,7 @@ include { setWorkflowArguments; getWorkflowArguments; passthroughMap as pmap } f
 
 config = readConfig("$workflowDir/multiomics/rna_singlesample/config.vsh.yaml")
 
-workflow {
+workflow rna_singlesample {
   helpMessage(config)
 
   channelFromParams(params, config)

--- a/workflows/qc/qc/config.vsh.yaml
+++ b/workflows/qc/qc/config.vsh.yaml
@@ -90,6 +90,7 @@ functionality:
   resources:
     - type: nextflow_script
       path: main.nf
+      entrypoint: qc_entrypoint
   test_resources:
     - type: nextflow_script
       path: main.nf

--- a/workflows/qc/qc/main.nf
+++ b/workflows/qc/qc/main.nf
@@ -11,7 +11,7 @@ include { readConfig; helpMessage; readCsv; preprocessInputs; channelFromParams 
 include { strictMap as smap; passthroughMap as pmap; } from workflowDir + "/utils/DataflowHelper.nf"
 config = readConfig("$workflowDir/qc/qc/config.vsh.yaml")
 
-workflow {
+workflow qc_entrypoint {
   helpMessage(config)
 
   channelFromParams(params, config)


### PR DESCRIPTION
## Changelog

* Bump viash to 0.8.0
* The `concat` component had been deprecated and will be removed in a future release. It's functionality has been copied to the `concatenate_h5mu` component because the name is in conflict with the `concat` operator from nextflow.
* All pipelines no longer use the anonymous workflow. Instead, these workflows were given a name which was added to the viash config as the entrypoint to the pipeline.

## Issue ticket number and link
Closes #597  (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [x] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!