### PR TITLE
Concatenation: fix order of var_names in concatenated object.

### DIFF
--- a/src/dataflow/concat/config.vsh.yaml
+++ b/src/dataflow/concat/config.vsh.yaml
@@ -53,6 +53,10 @@ functionality:
          - first: keep the annotation from the first sample
          - only: keep elements that show up in only one of the objects (1 unique element in only 1 sample)
          - move: identical to 'same', but moving the conflicting values to .varm or .obsm
+    - name: "--enable_assertions"
+      type: boolean_true
+      description: |
+        Enable assertions to check data integrity. Enabling this option may come at the cost of performance. 
   resources:
     - type: python_script
       path: script.py

--- a/src/dataflow/concat/config.vsh.yaml
+++ b/src/dataflow/concat/config.vsh.yaml
@@ -77,6 +77,8 @@ platforms:
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, .]
+        packages:
+          - muon
   - type: native
   - type: nextflow
     directives:

--- a/src/dataflow/concat/script.py
+++ b/src/dataflow/concat/script.py
@@ -222,7 +222,9 @@ def split_conflicts_modalities(n_processes: int, samples: dict[str, anndata.AnnD
             getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data.reindex(matrix_index)
 
         # Set other annotation matrices in the output
-        setattr(output, matrix_name, pd.DataFrame() if concatenated_matrix is None else concatenated_matrix)
+        setattr(output, matrix_name, 
+                pd.DataFrame() if concatenated_matrix is None \
+                else concatenated_matrix.reindex(matrix_index))
 
     return output
 

--- a/src/dataflow/concat/script.py
+++ b/src/dataflow/concat/script.py
@@ -18,7 +18,8 @@ par = {
     "output": "foo.h5mu",
     "input_id": ["mouse", "human"],
     "other_axis_mode": "move",
-    "output_compression": "gzip"
+    "output_compression": "gzip",
+    "enable_assertions": True
 }
 meta = {
     "cpus": 10,
@@ -121,7 +122,7 @@ def any_row_contains_duplicate_values(n_processes: int, frame: pd.DataFrame) -> 
         is_duplicated = pool.map(nunique, iter(numpy_array))
     return any(is_duplicated)
 
-def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame]) \
+def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame], align_to: pd.Index) \
     -> tuple[dict[str, pd.DataFrame], pd.DataFrame | None, dict[str, pd.core.dtypes.dtypes.Dtype]]:
     """
     Merge matrices by combining columns that have the same name.
@@ -131,14 +132,22 @@ def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame]) \
     column_names = set(column_name for var in matrices.values() for column_name in var)
     logger.debug('Trying to concatenate columns: %s.', ",".join(column_names))
     if not column_names:
-        return {}, None
+        return {}, pd.DataFrame(index=align_to)
     conflicts, concatenated_matrix = \
         split_conflicts_and_concatenated_columns(n_processes,
                                                  matrices,
-                                                 column_names)
+                                                 column_names,
+                                                 align_to)
     concatenated_matrix = cast_to_writeable_dtype(concatenated_matrix)
     conflicts = {conflict_name: cast_to_writeable_dtype(conflict_df) 
                  for conflict_name, conflict_df in conflicts.items()}
+    if par["enable_assertions"]: 
+        assert all([align_to.equals(to_check.index) for to_check in conflicts.values()]), \
+        "Runtime check failed: non-conflicting columns should have the same indices. "
+        "Please report this as a bug."
+        assert concatenated_matrix.index.equals(align_to), \
+        "Runtime check failed: annotation dataframe should have the same "
+        "index as the final MuData object. Please report this as a bug."
     return conflicts, concatenated_matrix
 
 def get_first_non_na_value_vector(df):
@@ -150,7 +159,8 @@ def get_first_non_na_value_vector(df):
 
 def split_conflicts_and_concatenated_columns(n_processes: int,
                                              matrices: dict[str, pd.DataFrame],
-                                             column_names: Iterable[str]) -> \
+                                             column_names: Iterable[str],
+                                             align_to: pd.Index) -> \
                                             tuple[dict[str, pd.DataFrame], pd.DataFrame]:
     """
     Retrieve columns with the same name from a list of dataframes which are
@@ -166,19 +176,23 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
                    for input_id, var in matrices.items()
                    if column_name in var}
         assert columns, "Some columns should have been found."
-        concatenated_columns = pd.concat(columns.values(), axis=1, join="outer")
+        concatenated_columns = pd.concat(columns.values(), axis=1, 
+                                         verify_integrity=par["enable_assertions"],
+                                         join="outer", sort=False)
+        concatenated_columns = concatenated_columns.reindex(align_to, copy=False) 
+        gc.collect()
         if any_row_contains_duplicate_values(n_processes, concatenated_columns):
             concatenated_columns.columns = columns.keys() # Use the sample id as column name
             conflicts[f'conflict_{column_name}'] = concatenated_columns
         else:
             unique_values = get_first_non_na_value_vector(concatenated_columns)
-            # concatenated_columns.fillna(method='bfill', axis=1).iloc[:, 0]
             concatenated_matrix.append(unique_values)
-    if concatenated_matrix:
-        concatenated_matrix = pd.concat(concatenated_matrix, join="outer", axis=1)
-    else:
-        concatenated_matrix = pd.DataFrame()
-
+    if not concatenated_matrix:
+        return conflicts, pd.DataFrame(index=align_to)
+    concatenated_matrix = pd.concat(concatenated_matrix, join="outer",
+                                    verify_integrity=par["enable_assertions"],
+                                    axis=1, sort=False)
+    concatenated_matrix = concatenated_matrix.reindex(align_to, copy=False)
     return conflicts, concatenated_matrix
 
 def cast_to_writeable_dtype(result: pd.DataFrame) -> pd.DataFrame:
@@ -214,17 +228,15 @@ def split_conflicts_modalities(n_processes: int, samples: dict[str, anndata.AnnD
     matrices_to_parse = ("var", "obs")
     for matrix_name in matrices_to_parse:
         matrices = {sample_id: getattr(sample, matrix_name) for sample_id, sample in samples.items()}
-        conflicts, concatenated_matrix = concatenate_matrices(n_processes, matrices)
+        output_index = getattr(output, matrix_name).index
+        conflicts, concatenated_matrix = concatenate_matrices(n_processes, matrices, output_index)
         
         # Write the conflicts to the output
-        matrix_index = getattr(output, matrix_name).index
         for conflict_name, conflict_data in conflicts.items():
-            getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data.reindex(matrix_index)
+            getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data
 
         # Set other annotation matrices in the output
-        setattr(output, matrix_name, 
-                pd.DataFrame() if concatenated_matrix is None \
-                else concatenated_matrix.reindex(matrix_index))
+        setattr(output, matrix_name, concatenated_matrix)
 
     return output
 

--- a/src/dataflow/concat/script.py
+++ b/src/dataflow/concat/script.py
@@ -180,7 +180,6 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
                                          verify_integrity=par["enable_assertions"],
                                          join="outer", sort=False)
         concatenated_columns = concatenated_columns.reindex(align_to, copy=False) 
-        gc.collect()
         if any_row_contains_duplicate_values(n_processes, concatenated_columns):
             concatenated_columns.columns = columns.keys() # Use the sample id as column name
             conflicts[f'conflict_{column_name}'] = concatenated_columns

--- a/src/dataflow/concat/test.py
+++ b/src/dataflow/concat/test.py
@@ -444,11 +444,10 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
     assert Path("concat.h5mu").is_file() is True
     concatenated_data = md.read("concat.h5mu")
 
-    data_sample1 = md.read(sample1_without_genome)
-    data_sample2 = md.read(input_sample2_file)
-    for sample_name, sample in {"mouse": data_sample1, "human": data_sample2}.items():
-        for mod_name in sample.mod.keys():
-            data_sample = sample.mod[mod_name]
+    for sample_name, sample_path in {"mouse": sample1_without_genome, 
+                                     "human": input_sample2_file}.items():
+        for mod_name in ["rna", "atac"]:
+            data_sample = md.read_h5ad(sample_path, mod=mod_name)
             processed_data = concatenated_data.mod[mod_name].copy()
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)

--- a/src/dataflow/concat/test.py
+++ b/src/dataflow/concat/test.py
@@ -7,6 +7,7 @@ import pytest
 import re
 import sys
 import uuid
+import muon
 
 ## VIASH START
 meta = {
@@ -418,6 +419,41 @@ def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
                 ])
         assert re.search(rf"OSError: Failed to load .*{str(empty_file)}\. Is it a valid h5 file?",
             err.value.stdout.decode('utf-8'))
+        
+
+@pytest.mark.parametrize("mudata_without_genome",
+                          [([input_sample1_file], ["rna", "atac"])],
+                          indirect=["mudata_without_genome"])
+def test_concat_var_obs_names_order(run_component, mudata_without_genome):
+    """
+    Test what happens when concatenating samples with differing auxiliary
+    (like in .var) columns (present in 1 sample, absent in other).
+    When concatenating the samples, all columns should be present in the
+    resulting object, filling the values from samples with the missing
+    column with NA.
+    """
+    [sample1_without_genome,] = mudata_without_genome
+    run_component([
+            "--input_id", "mouse,human",
+            "--input", sample1_without_genome,
+            "--input", input_sample2_file,
+            "--output", "concat.h5mu",
+            "--other_axis_mode", "move"
+            ])
+
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+
+    data_sample1 = md.read(sample1_without_genome)
+    data_sample2 = md.read(input_sample2_file)
+    for sample_name, sample in {"mouse": data_sample1, "human": data_sample2}.items():
+        for mod_name in sample.mod.keys():
+            data_sample = sample.mod[mod_name]
+            processed_data = concatenated_data.mod[mod_name].copy()
+            muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
+            muon.pp.filter_var(processed_data, data_sample.var_names)
+            pd.testing.assert_frame_equal(data_sample.to_df().sort_index().sort_index(axis=1), 
+                                          processed_data.to_df().sort_index().sort_index(axis=1))
 
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__, "-v"]))

--- a/src/dataflow/concat/test.py
+++ b/src/dataflow/concat/test.py
@@ -440,15 +440,13 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
             "--output", "concat.h5mu",
             "--other_axis_mode", "move"
             ])
-
+    print("FINISHED", flush=True)
     assert Path("concat.h5mu").is_file() is True
-    concatenated_data = md.read("concat.h5mu")
-
     for sample_name, sample_path in {"mouse": sample1_without_genome, 
                                      "human": input_sample2_file}.items():
         for mod_name in ["rna", "atac"]:
             data_sample = md.read_h5ad(sample_path, mod=mod_name)
-            processed_data = concatenated_data.mod[mod_name].copy()
+            processed_data = md.read_h5ad("concat.h5mu", mod=mod_name)
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)
             data_sample_to_test = data_sample.to_df()

--- a/src/dataflow/concat/test.py
+++ b/src/dataflow/concat/test.py
@@ -452,8 +452,13 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
             processed_data = concatenated_data.mod[mod_name].copy()
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)
-            pd.testing.assert_frame_equal(data_sample.to_df().sort_index().sort_index(axis=1), 
-                                          processed_data.to_df().sort_index().sort_index(axis=1))
+            data_sample_to_test = data_sample.to_df()
+            data_sample_to_test.sort_index(inplace=True)
+            data_sample_to_test.sort_index(axis=1, inplace=True)
+            processed_data_to_test = processed_data.to_df()
+            processed_data_to_test.sort_index(inplace=True)
+            processed_data_to_test.sort_index(axis=1, inplace=True)
+            pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test)
 
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__, "-v"]))

--- a/src/dataflow/concatenate_h5mu/config.vsh.yaml
+++ b/src/dataflow/concatenate_h5mu/config.vsh.yaml
@@ -76,6 +76,8 @@ platforms:
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, .]
+        packages:
+          - muon
   - type: native
   - type: nextflow
     directives:

--- a/src/dataflow/concatenate_h5mu/config.vsh.yaml
+++ b/src/dataflow/concatenate_h5mu/config.vsh.yaml
@@ -52,6 +52,10 @@ functionality:
          - first: keep the annotation from the first sample
          - only: keep elements that show up in only one of the objects (1 unique element in only 1 sample)
          - move: identical to 'same', but moving the conflicting values to .varm or .obsm
+    - name: "--enable_assertions"
+      type: boolean_true
+      description: |
+        Enable assertions to check data integrity. Enabling this option may come at the cost of performance. 
   resources:
     - type: python_script
       path: script.py

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -222,7 +222,9 @@ def split_conflicts_modalities(n_processes: int, samples: dict[str, anndata.AnnD
             getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data.reindex(matrix_index)
 
         # Set other annotation matrices in the output
-        setattr(output, matrix_name, pd.DataFrame() if concatenated_matrix is None else concatenated_matrix)
+        setattr(output, matrix_name, 
+                pd.DataFrame() if concatenated_matrix is None \
+                else concatenated_matrix.reindex(matrix_index))
 
     return output
 

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from h5py import File as H5File
 from typing import Literal
 import shutil
+import gc
 
 ### VIASH START
 par = {
@@ -180,6 +181,7 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
                                          verify_integrity=par["enable_assertions"],
                                          join="outer", sort=False)
         concatenated_columns = concatenated_columns.reindex(align_to, copy=False) 
+        gc.collect()
         if any_row_contains_duplicate_values(n_processes, concatenated_columns):
             concatenated_columns.columns = columns.keys() # Use the sample id as column name
             conflicts[f'conflict_{column_name}'] = concatenated_columns
@@ -191,7 +193,9 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
     concatenated_matrix = pd.concat(concatenated_matrix, join="outer",
                                     verify_integrity=par["enable_assertions"],
                                     axis=1, sort=False)
-    return conflicts, concatenated_matrix.reindex(align_to, copy=False)
+    concatenated_matrix = concatenated_matrix.reindex(align_to, copy=False)
+    gc.collect()
+    return conflicts, concatenated_matrix
 
 def cast_to_writeable_dtype(result: pd.DataFrame) -> pd.DataFrame:
     """

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -18,7 +18,8 @@ par = {
     "output": "foo.h5mu",
     "input_id": ["mouse", "human"],
     "other_axis_mode": "move",
-    "output_compression": "gzip"
+    "output_compression": "gzip",
+    "enable_assertions": True
 }
 meta = {
     "cpus": 10,
@@ -121,7 +122,7 @@ def any_row_contains_duplicate_values(n_processes: int, frame: pd.DataFrame) -> 
         is_duplicated = pool.map(nunique, iter(numpy_array))
     return any(is_duplicated)
 
-def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame]) \
+def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame], align_to: pd.Index) \
     -> tuple[dict[str, pd.DataFrame], pd.DataFrame | None, dict[str, pd.core.dtypes.dtypes.Dtype]]:
     """
     Merge matrices by combining columns that have the same name.
@@ -131,14 +132,22 @@ def concatenate_matrices(n_processes: int, matrices: dict[str, pd.DataFrame]) \
     column_names = set(column_name for var in matrices.values() for column_name in var)
     logger.debug('Trying to concatenate columns: %s.', ",".join(column_names))
     if not column_names:
-        return {}, None
+        return {}, pd.DataFrame(index=align_to)
     conflicts, concatenated_matrix = \
         split_conflicts_and_concatenated_columns(n_processes,
                                                  matrices,
-                                                 column_names)
+                                                 column_names,
+                                                 align_to)
     concatenated_matrix = cast_to_writeable_dtype(concatenated_matrix)
     conflicts = {conflict_name: cast_to_writeable_dtype(conflict_df) 
                  for conflict_name, conflict_df in conflicts.items()}
+    if par["enable_assertions"]: 
+        assert all([align_to.equals(to_check.index) for to_check in conflicts.values()]), \
+        "Runtime check failed: non-conflicting columns should have the same indices. "
+        "Please report this as a bug."
+        assert concatenated_matrix.index.equals(align_to), \
+        "Runtime check failed: annotation dataframe should have the same "
+        "index as the final MuData object. Please report this as a bug."
     return conflicts, concatenated_matrix
 
 def get_first_non_na_value_vector(df):
@@ -150,7 +159,8 @@ def get_first_non_na_value_vector(df):
 
 def split_conflicts_and_concatenated_columns(n_processes: int,
                                              matrices: dict[str, pd.DataFrame],
-                                             column_names: Iterable[str]) -> \
+                                             column_names: Iterable[str],
+                                             align_to: pd.Index) -> \
                                             tuple[dict[str, pd.DataFrame], pd.DataFrame]:
     """
     Retrieve columns with the same name from a list of dataframes which are
@@ -160,25 +170,43 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
     with the same name that store conflicting values.
     """
     conflicts = {}
-    concatenated_matrix = []
+    # Observations are unique, so check for a one-to-one join of the indexes
+    # one-to-one: check if join keys are unique in both left and right datasets.
+    validate = None if not par["enable_assertions"] else "one_to_one"
+    columns_to_join = []
     for column_name in column_names:
-        columns = {input_id: var[column_name]
+        # rename: use sample ids as the name of the column
+        # as pandas' join() requires unique column names
+        columns = {input_id: var[column_name].rename(input_id)
                    for input_id, var in matrices.items()
                    if column_name in var}
         assert columns, "Some columns should have been found."
-        concatenated_columns = pd.concat(columns.values(), axis=1, join="outer")
+        concatenated_columns = pd.DataFrame(index=align_to).join(columns.values(), validate=validate, 
+                                                                 how="left", sort=False)
         if any_row_contains_duplicate_values(n_processes, concatenated_columns):
-            concatenated_columns.columns = columns.keys() # Use the sample id as column name
+            if par["enable_assertions"]:
+                assert concatenated_columns.index.equals(align_to), \
+                "Runtime check failed: conflicting columns dataframe should have the same index "
+                "as the final concatenated MuData object. Please report this as a bug."
             conflicts[f'conflict_{column_name}'] = concatenated_columns
         else:
             unique_values = get_first_non_na_value_vector(concatenated_columns)
-            # concatenated_columns.fillna(method='bfill', axis=1).iloc[:, 0]
-            concatenated_matrix.append(unique_values)
-    if concatenated_matrix:
-        concatenated_matrix = pd.concat(concatenated_matrix, join="outer", axis=1)
-    else:
-        concatenated_matrix = pd.DataFrame()
-
+             # overwrite the column name from sample ID with the original annotation column name
+            unique_values.name = column_name
+            columns_to_join.append(unique_values)
+    if par["enable_assertions"]:
+        assert all([columns_to_join[0].index.equals(to_check.index) 
+                    for to_check in columns_to_join]), \
+        "Runtime check failed: non-conflicting columns should have the same indices. "
+        "Please report this as a bug."
+    concatenated_matrix = pd.DataFrame(index=align_to)
+    concatenated_matrix = concatenated_matrix.join(columns_to_join, how="left", 
+                                                   sort=False, validate=validate)
+    if par["enable_assertions"]:
+        assert concatenated_matrix.index.equals(align_to), \
+        "Runtime check failed: annotation dataframe should have "
+        "the same index as the final MuData object. Please report "
+        "this as a bug."
     return conflicts, concatenated_matrix
 
 def cast_to_writeable_dtype(result: pd.DataFrame) -> pd.DataFrame:
@@ -214,17 +242,15 @@ def split_conflicts_modalities(n_processes: int, samples: dict[str, anndata.AnnD
     matrices_to_parse = ("var", "obs")
     for matrix_name in matrices_to_parse:
         matrices = {sample_id: getattr(sample, matrix_name) for sample_id, sample in samples.items()}
-        conflicts, concatenated_matrix = concatenate_matrices(n_processes, matrices)
+        output_index = getattr(output, matrix_name).index
+        conflicts, concatenated_matrix = concatenate_matrices(n_processes, matrices, output_index)
         
         # Write the conflicts to the output
-        matrix_index = getattr(output, matrix_name).index
         for conflict_name, conflict_data in conflicts.items():
-            getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data.reindex(matrix_index)
+            getattr(output, f"{matrix_name}m")[conflict_name] = conflict_data
 
         # Set other annotation matrices in the output
-        setattr(output, matrix_name, 
-                pd.DataFrame() if concatenated_matrix is None \
-                else concatenated_matrix.reindex(matrix_index))
+        setattr(output, matrix_name, concatenated_matrix)
 
     return output
 

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -194,7 +194,6 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
                                     verify_integrity=par["enable_assertions"],
                                     axis=1, sort=False)
     concatenated_matrix = concatenated_matrix.reindex(align_to, copy=False)
-    gc.collect()
     return conflicts, concatenated_matrix
 
 def cast_to_writeable_dtype(result: pd.DataFrame) -> pd.DataFrame:

--- a/src/dataflow/concatenate_h5mu/script.py
+++ b/src/dataflow/concatenate_h5mu/script.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from h5py import File as H5File
 from typing import Literal
 import shutil
-import gc
 
 ### VIASH START
 par = {
@@ -181,7 +180,6 @@ def split_conflicts_and_concatenated_columns(n_processes: int,
                                          verify_integrity=par["enable_assertions"],
                                          join="outer", sort=False)
         concatenated_columns = concatenated_columns.reindex(align_to, copy=False) 
-        gc.collect()
         if any_row_contains_duplicate_values(n_processes, concatenated_columns):
             concatenated_columns.columns = columns.keys() # Use the sample id as column name
             conflicts[f'conflict_{column_name}'] = concatenated_columns

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -466,4 +466,4 @@ def test_concat_var_obs_names_order(run_component_with_assertions, mudata_withou
             # pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test, check_like=True)
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__, "-v", "-x"]))
+    sys.exit(pytest.main([__file__, "-v", "-x", "--log-cli-level"]))

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -454,7 +454,7 @@ def test_concat_var_obs_names_order(run_component_with_assertions, mudata_withou
     for sample_name, sample_path in {"mouse": sample1_without_genome, 
                                      "human": input_sample2_file}.items():
         for mod_name in ["rna", "atac"]:
-            data_sample = md.read_h5ad(sample_path, mod=mod_name)
+            data_sample = md.read_h5ad(sample_path, mod=mod_name, backed='r')
             processed_data = md.read_h5ad("concat.h5mu", mod=mod_name)
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -9,6 +9,7 @@ import sys
 import uuid
 import muon
 
+enable_runtime_assertions = False
 ## VIASH START
 meta = {
     'executable': './target/docker/dataflow/concatenate_h5mu/concatenate_h5mu',
@@ -16,6 +17,7 @@ meta = {
     'cpus': 2,
     'config': './src/dataflow/concatenate_h5mu/config.vsh.yaml'
 }
+enable_runtime_assertions = True
 ## VIASH END
 
 meta['cpus'] = 1 if not meta['cpus'] else meta['cpus']
@@ -107,7 +109,8 @@ def copied_mudata_with_extra_annotation_column(tmp_path, mudata_copy_with_unique
 @pytest.fixture
 def run_component_with_assertions(run_component):
     def wrapper(args_as_list):
-        args_as_list.append("--enable_assertions")
+        if enable_runtime_assertions:
+            args_as_list.append("--enable_assertions")
         return run_component(args_as_list)
     return wrapper
 

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -444,11 +444,10 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
     assert Path("concat.h5mu").is_file() is True
     concatenated_data = md.read("concat.h5mu")
 
-    data_sample1 = md.read(sample1_without_genome)
-    data_sample2 = md.read(input_sample2_file)
-    for sample_name, sample in {"mouse": data_sample1, "human": data_sample2}.items():
-        for mod_name in sample.mod.keys():
-            data_sample = sample.mod[mod_name]
+    for sample_name, sample_path in {"mouse": sample1_without_genome, 
+                                     "human": input_sample2_file}.items():
+        for mod_name in ["rna", "atac"]:
+            data_sample = md.read_h5ad(sample_path, mod=mod_name)
             processed_data = concatenated_data.mod[mod_name].copy()
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -7,6 +7,7 @@ import pytest
 import re
 import sys
 import uuid
+import muon
 
 ## VIASH START
 meta = {
@@ -418,6 +419,41 @@ def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
                 ])
         assert re.search(rf"OSError: Failed to load .*{str(empty_file)}\. Is it a valid h5 file?",
             err.value.stdout.decode('utf-8'))
+        
+
+@pytest.mark.parametrize("mudata_without_genome",
+                          [([input_sample1_file], ["rna", "atac"])],
+                          indirect=["mudata_without_genome"])
+def test_concat_var_obs_names_order(run_component, mudata_without_genome):
+    """
+    Test what happens when concatenating samples with differing auxiliary
+    (like in .var) columns (present in 1 sample, absent in other).
+    When concatenating the samples, all columns should be present in the
+    resulting object, filling the values from samples with the missing
+    column with NA.
+    """
+    [sample1_without_genome,] = mudata_without_genome
+    run_component([
+            "--input_id", "mouse,human",
+            "--input", sample1_without_genome,
+            "--input", input_sample2_file,
+            "--output", "concat.h5mu",
+            "--other_axis_mode", "move"
+            ])
+
+    assert Path("concat.h5mu").is_file() is True
+    concatenated_data = md.read("concat.h5mu")
+
+    data_sample1 = md.read(sample1_without_genome)
+    data_sample2 = md.read(input_sample2_file)
+    for sample_name, sample in {"mouse": data_sample1, "human": data_sample2}.items():
+        for mod_name in sample.mod.keys():
+            data_sample = sample.mod[mod_name]
+            processed_data = concatenated_data.mod[mod_name].copy()
+            muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
+            muon.pp.filter_var(processed_data, data_sample.var_names)
+            pd.testing.assert_frame_equal(data_sample.to_df().sort_index().sort_index(axis=1), 
+                                          processed_data.to_df().sort_index().sort_index(axis=1))
 
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__, "-v"]))

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -440,15 +440,13 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
             "--output", "concat.h5mu",
             "--other_axis_mode", "move"
             ])
-
+    print("FINISHED", flush=True)
     assert Path("concat.h5mu").is_file() is True
-    concatenated_data = md.read("concat.h5mu")
-
     for sample_name, sample_path in {"mouse": sample1_without_genome, 
                                      "human": input_sample2_file}.items():
         for mod_name in ["rna", "atac"]:
             data_sample = md.read_h5ad(sample_path, mod=mod_name)
-            processed_data = concatenated_data.mod[mod_name].copy()
+            processed_data = md.read_h5ad("concat.h5mu", mod=mod_name)
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)
             data_sample_to_test = data_sample.to_df()

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -459,12 +459,8 @@ def test_concat_var_obs_names_order(run_component_with_assertions, mudata_withou
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)
             data_sample_to_test = data_sample.to_df()
-            data_sample_to_test.sort_index(inplace=True)
-            data_sample_to_test.sort_index(axis=1, inplace=True)
             processed_data_to_test = processed_data.to_df()
-            processed_data_to_test.sort_index(inplace=True)
-            processed_data_to_test.sort_index(axis=1, inplace=True)
-            pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test)
+            pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test, check_like=True)
 
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__, "-v", "-x"]))

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -452,8 +452,13 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome):
             processed_data = concatenated_data.mod[mod_name].copy()
             muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
             muon.pp.filter_var(processed_data, data_sample.var_names)
-            pd.testing.assert_frame_equal(data_sample.to_df().sort_index().sort_index(axis=1), 
-                                          processed_data.to_df().sort_index().sort_index(axis=1))
+            data_sample_to_test = data_sample.to_df()
+            data_sample_to_test.sort_index(inplace=True)
+            data_sample_to_test.sort_index(axis=1, inplace=True)
+            processed_data_to_test = processed_data.to_df()
+            processed_data_to_test.sort_index(inplace=True)
+            processed_data_to_test.sort_index(axis=1, inplace=True)
+            pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test)
 
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__, "-v"]))

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -466,4 +466,4 @@ def test_concat_var_obs_names_order(run_component_with_assertions, mudata_withou
             # pd.testing.assert_frame_equal(data_sample_to_test, processed_data_to_test, check_like=True)
 
 if __name__ == '__main__':
-    sys.exit(pytest.main([__file__, "-v", "-x", "--log-cli-level"]))
+    sys.exit(pytest.main([__file__, "-v", "-x", "--log-cli-level", "INFO", "-k", "test_concat_var_obs_names_order"]))


### PR DESCRIPTION
## Changelog

Concatenation: fix order of var_names in concatenated object.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!