### PR TITLE
Fix calculating qc metrics when var_qc_metrics columns are BooleanArrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 * `dataflow/concatenate_h5mu` and `dataflow/concat`: Fix an issue where joining columns with different datatypes caused `TypeError` (PR #619).
 
+* `qc/calculate_qc_metrics`: Resolved an issue where statistics based on the input columns selected with `--var_qc_metrics` were incorrect when these input columns were encoded in `pd.BooleanDtype()` (PR #685).
+
 # openpipelines 0.12.1
 
 ## BUG FIXES

--- a/src/qc/calculate_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_qc_metrics/config.vsh.yaml
@@ -129,7 +129,7 @@ functionality:
     - path: /src/utils/setup_logger.py
   test_resources:
     - type: python_script
-      path: test_qc.py
+      path: test.py
     - path: /resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu
 platforms:
   - type: docker

--- a/src/qc/calculate_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_qc_metrics/config.vsh.yaml
@@ -142,7 +142,6 @@ platforms:
         __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
         packages:
           - scikit-learn~=1.2.0
-          - pandas~=2.1.0
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, /src/base/requirements/scanpy.yaml, .]

--- a/src/qc/calculate_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_qc_metrics/config.vsh.yaml
@@ -129,7 +129,7 @@ functionality:
     - path: /src/utils/setup_logger.py
   test_resources:
     - type: python_script
-      path: test.py
+      path: test_qc.py
     - path: /resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu
 platforms:
   - type: docker
@@ -142,6 +142,7 @@ platforms:
         __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
         packages:
           - scikit-learn~=1.2.0
+          - pandas~=2.1.0
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, /src/base/requirements/scanpy.yaml, .]

--- a/src/qc/calculate_qc_metrics/script.py
+++ b/src/qc/calculate_qc_metrics/script.py
@@ -98,7 +98,7 @@ def main():
                                      "You can explicitly map the NA values to 'False' or 'True using '--var_qc_metrics_fill_na_value'")
                 else:
                     qc_column = qc_column.fillna(par['var_qc_metrics_fill_na_value'], inplace=False)
-            qc_column = qc_column.values
+            qc_column = qc_column.to_list()
             if set(np.unique(qc_column)) - {True, False}:
                 raise ValueError(f"Column {qc_metric} in .var for modality {par['modality']} "
                                  f"must only contain boolean values")

--- a/src/qc/calculate_qc_metrics/script.py
+++ b/src/qc/calculate_qc_metrics/script.py
@@ -98,7 +98,7 @@ def main():
                                      "You can explicitly map the NA values to 'False' or 'True using '--var_qc_metrics_fill_na_value'")
                 else:
                     qc_column = qc_column.fillna(par['var_qc_metrics_fill_na_value'], inplace=False)
-            qc_column = qc_column.to_list()
+            qc_column = qc_column.values
             if set(np.unique(qc_column)) - {True, False}:
                 raise ValueError(f"Column {qc_metric} in .var for modality {par['modality']} "
                                  f"must only contain boolean values")

--- a/src/qc/calculate_qc_metrics/test.py
+++ b/src/qc/calculate_qc_metrics/test.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import mudata as md
 import numpy as np
 import scanpy as sc
+import pandas as pd
+import scipy
+import uuid
 from pandas.testing import assert_series_equal
+from itertools import product
+
 
 ## VIASH START
 meta = {
@@ -22,42 +27,31 @@ def input_path():
 
 @pytest.fixture
 def input_mudata(input_path):
-    return md.read_h5mu(input_path)
-
-
-@pytest.fixture
-def mudata_w_na_boolean_colum(tmp_path, input_mudata):
-    input_var = input_mudata.mod['rna'].var
-    input_var["custom"] = np.nan
-
-    new_input_path = tmp_path / "input_with_custom_col.h5mu"
-    input_mudata.write(new_input_path)
-    return new_input_path
+    mudata = md.read_h5mu(input_path)
+    # create a less sparse matrix to increase the variability in qc statistics
+    rng = np.random.default_rng()
+    random_counts = scipy.sparse.random(*mudata['rna'].X.shape,
+                                        density=0.8,
+                                        format='csr',
+                                        random_state=rng)
+    mudata['rna'].X = random_counts
+    return mudata
 
 @pytest.fixture
-def mudata_w_false_boolean_colum(tmp_path, input_mudata):
+def input_mudata_path(tmp_path, input_mudata):
+    output_path = tmp_path / f"{str(uuid.uuid4())}.h5mu"
+    input_mudata.write(output_path)
+    return output_path
+
+@pytest.fixture(params=product([True, False, np.nan, "random"],
+                               ["bool", pd.BooleanDtype()]))
+def mudata_with_boolean_column(tmp_path, input_mudata, request):
+    requested_value, requested_type = request.param
     input_var = input_mudata.mod['rna'].var
-    input_var["custom"] = True
-
-    new_input_path = tmp_path / "input_with_custom_col.h5mu"
-    input_mudata.write(new_input_path)
-    return new_input_path
-
-
-@pytest.fixture
-def mudata_w_true_boolean_colum(tmp_path, input_mudata):
-    input_var = input_mudata.mod['rna'].var
-    input_var["custom"] = True
-
-    new_input_path = tmp_path / "input_with_custom_col.h5mu"
-    input_mudata.write(new_input_path)
-    return new_input_path
-
-@pytest.fixture
-def mudata_w_random_boolean_column(tmp_path, input_mudata):
-    input_var = input_mudata.mod['rna'].var
-    input_var["custom"] = np.random.choice([True, False], len(input_var), p=[0.8, 0.2])
-
+    input_var["custom"] =  requested_value
+    if requested_value == "random":
+        input_var["custom"] = np.random.choice([True, False], len(input_var), p=[0.20, 0.80])
+    input_var["custom"] = input_var["custom"].astype(requested_type) 
     new_input_path = tmp_path / "input_with_custom_col.h5mu"
     input_mudata.write(new_input_path)
     return new_input_path
@@ -92,13 +86,13 @@ def test_add_qc(run_component, input_path):
                           ("--output_var_obs_mean", "var", "sit", "sit"),
                           ("--output_var_pct_dropout", "var", "elit", "elit")])
 def test_qc_metrics_set_output_column(run_component,
-                                      mudata_w_random_boolean_column,
+                                      input_mudata_path,
                                       optional_parameter,
                                       annotation_matrix,
                                       arg_value,
                                       expected_name):
     args = [
-        "--input", mudata_w_random_boolean_column,
+        "--input", input_mudata_path,
         "--output", "foo.h5mu",
         "--modality", "rna",
         "--output_compression", "gzip",
@@ -121,12 +115,12 @@ def test_qc_metrics_set_output_column(run_component,
                           ("--output_var_obs_mean", "var", "obs_mean"),
                           ("--output_var_pct_dropout", "var", "pct_dropout")])
 def test_qc_metrics_optional(run_component,
-                             mudata_w_random_boolean_column,
+                             input_mudata_path,
                              optional_parameter,
                              annotation_matrix,
                              expected_missing):
     args = [
-        "--input", mudata_w_random_boolean_column,
+        "--input", input_mudata_path,
         "--output", "foo.h5mu",
         "--modality", "rna",
         "--output_compression", "gzip"
@@ -140,49 +134,56 @@ def test_qc_metrics_optional(run_component,
     matrix = getattr(data_with_qc.mod['rna'], annotation_matrix)
     assert matrix.filter(regex=expected_missing, axis=1).empty
 
-@pytest.mark.parametrize("edited_input_mudata", ["mudata_w_true_boolean_colum",
-                                                 "mudata_w_false_boolean_colum",
-                                                 "mudata_w_na_boolean_colum",
-                                                 "mudata_w_random_boolean_column"])
-def test_calculcate_qc_var_qc_metrics(run_component, request, edited_input_mudata, tmp_path):
-    input_path = request.getfixturevalue(edited_input_mudata)
+def test_calculcate_qc_var_qc_metrics(run_component, mudata_with_boolean_column, tmp_path):
     output_path = tmp_path / "foo.h5mu"
-
+    input_data = md.read_h5mu(mudata_with_boolean_column)
     args = [
-        "--input", str(input_path),
+        "--input", str(mudata_with_boolean_column),
         "--output", str(output_path),
         "--modality", "rna",
         "--top_n_vars", "10,20,90",
         "--var_qc_metrics", "custom",
     ]
-    if edited_input_mudata == "mudata_w_na_boolean_colum":
+    if input_data.mod['rna'].var["custom"].isna().any():
         args.extend(["--var_qc_metrics_fill_na_value", "True"])
 
     run_component(args)
     assert output_path.is_file()
-    data_with_qc = md.read(output_path)
+    data_with_qc = md.read(output_path)['rna']
     for qc_metric in ('pct_custom', 'total_counts_custom'):
-        assert qc_metric in data_with_qc.mod['rna'].obs
+        assert qc_metric in data_with_qc.obs
+    # Do a percentage calculation based on indexes
+    # and compare it to the calculations from the component
+    custom_column_true = data_with_qc.var['custom'].fillna(True)
+    gene_counts = sc.get.obs_df(data_with_qc, keys=data_with_qc.var_names.to_list())
+    gene_counts_custom = gene_counts.loc[:,custom_column_true]
+    sum_custom_column = gene_counts_custom.sum(axis=1)
+    sum_all = gene_counts.sum(axis=1)
+    percentage = (sum_custom_column / sum_all) * 100
+    assert (percentage == data_with_qc.obs['pct_custom']).all()
+    assert (data_with_qc.obs['pct_custom'] <= 100).all()
 
 def test_compare_scanpy(run_component,
-                        mudata_w_random_boolean_column,
+                        mudata_with_boolean_column,
                         input_mudata,
                         tmp_path):
     
     output_path = tmp_path / "foo.h5mu"
 
     run_component([
-        "--input", str(mudata_w_random_boolean_column),
+        "--input", str(mudata_with_boolean_column),
         "--output", str(output_path),
         "--modality", "rna",
         "--top_n_vars", "10,20,90",
         "--var_qc_metrics", "custom",
+        "--var_qc_metrics_fill_na_value", "False"
         ])
     assert output_path.is_file()
 
     component_data = md.read(output_path)
     rna_mod = component_data.mod['rna']
 
+    input_mudata.mod['rna'].var['custom'] = input_mudata.mod['rna'].var['custom'].fillna(False)
     sc.pp.calculate_qc_metrics(
         input_mudata.mod['rna'],
         expr_type="counts",

--- a/src/qc/calculate_qc_metrics/test.py
+++ b/src/qc/calculate_qc_metrics/test.py
@@ -25,7 +25,7 @@ meta = {
 def input_path():
     return f"{meta['resources_dir']}/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"
 
-@pytest.fixture()
+@pytest.fixture
 def input_mudata(input_path):
     mudata = md.read_h5mu(input_path)
     # create a less sparse matrix to increase the variability in qc statistics

--- a/src/qc/calculate_qc_metrics/test.py
+++ b/src/qc/calculate_qc_metrics/test.py
@@ -185,7 +185,10 @@ def test_compare_scanpy(run_component,
     component_data = md.read(output_path)
     rna_mod = component_data.mod['rna']
 
-    input_mudata.mod['rna'].var['custom'] = input_mudata.mod['rna'].var['custom'].fillna(False)
+    # Replicate --var_qc_metrics_fill_na_value False
+    # Scanpy also does not work with pd.BooleanDtype()
+    # So cast from 'boolean' to 'bool'
+    input_mudata.mod['rna'].var['custom'] = input_mudata.mod['rna'].var['custom'].fillna(False).astype("bool")
     sc.pp.calculate_qc_metrics(
         input_mudata.mod['rna'],
         expr_type="counts",

--- a/src/qc/calculate_qc_metrics/test.py
+++ b/src/qc/calculate_qc_metrics/test.py
@@ -25,7 +25,7 @@ meta = {
 def input_path():
     return f"{meta['resources_dir']}/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"
 
-@pytest.fixture
+@pytest.fixture()
 def input_mudata(input_path):
     mudata = md.read_h5mu(input_path)
     # create a less sparse matrix to increase the variability in qc statistics
@@ -160,7 +160,9 @@ def test_calculcate_qc_var_qc_metrics(run_component, mudata_with_boolean_column,
     sum_custom_column = gene_counts_custom.sum(axis=1)
     sum_all = gene_counts.sum(axis=1)
     percentage = (sum_custom_column / sum_all) * 100
-    assert (percentage == data_with_qc.obs['pct_custom']).all()
+    pd.testing.assert_series_equal(percentage, data_with_qc.obs['pct_custom'],
+                                   check_exact=False, # Comparing floats
+                                   check_names=False)
     assert (data_with_qc.obs['pct_custom'] <= 100).all()
 
 def test_compare_scanpy(run_component,


### PR DESCRIPTION
## Changelog

Fix calculating qc metrics when var_qc_metrics columns are BooleanArrays (with dtype `pd.BooleanDtype()` instead of `dtype('bool')`) with pandas 2.1.x

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!