### PR TITLE
move_obsm_to_obs: fix setting output columns when they already exist.

### DIFF
--- a/src/metadata/move_obsm_to_obs/script.py
+++ b/src/metadata/move_obsm_to_obs/script.py
@@ -47,9 +47,11 @@ original_n_obs = len(mod_data.obs)
 try:
     logger.info(f".obs names: {mod_data.obs_names}")
     logger.info(f".obsm index: {obsm_matrix.index}")
-    mod_data.obs = mod_data.obs.merge(obsm_matrix, how="left",
-                                      validate="one_to_one",
-                                      left_index=True, right_index=True)
+    new_obs = mod_data.obs.drop(obsm_matrix.columns, axis=1, errors="ignore")
+    new_obs = new_obs.merge(obsm_matrix, how="left",
+                            validate="one_to_one",
+                            left_index=True, right_index=True)
+    mod_data.obs = new_obs
 except MergeError as e:
     raise ValueError(f"Could not join .obsm matrix at {par['obsm_key']} to .obs because there "
                      "are some observation that are not overlapping between the two matrices "

--- a/src/metadata/move_obsm_to_obs/test.py
+++ b/src/metadata/move_obsm_to_obs/test.py
@@ -1,6 +1,7 @@
 import pytest
 import re
 import pandas as pd
+import uuid
 from anndata import AnnData
 from mudata import MuData, read_h5mu
 from subprocess import CalledProcessError
@@ -10,7 +11,7 @@ meta = {
     'functionality_name': 'move_obsm_to_obs',
     'resources_dir': 'resources_test/',
     'executable': 'target/docker/metadata/move_obsm_to_obs/move_obsm_to_obs',
-    'config': '/home/di/code/openpipeline/src/metadata/move_obsm_to_obs/config.vsh.yaml'
+    'config': 'src/metadata/move_obsm_to_obs/config.vsh.yaml'
 }
 ## VIASH END
 
@@ -31,9 +32,9 @@ def h5mu():
 @pytest.fixture
 def write_temp_h5mu(tmp_path):
     def wrapper(test_h5mu): 
-        test_h5mu_path = tmp_path / "input.h5mu"
-        test_h5mu.write_h5mu(test_h5mu_path.name)
-        return test_h5mu_path.name
+        test_h5mu_path = tmp_path / f"{str(uuid.uuid4())}.h5mu"
+        test_h5mu.write_h5mu(test_h5mu_path)
+        return test_h5mu_path
     return wrapper
 
 @pytest.fixture
@@ -80,6 +81,33 @@ def test_error_non_existing_modality(run_component, h5mu, write_temp_h5mu, tmp_p
                     ])
     re.search(r"ValueError: Modality foo does not exist\.",
         err.value.stdout.decode('utf-8'))
+    
+def test_execute_twice_overwrites(run_component, h5mu, write_temp_h5mu, tmp_path):
+    output_run_1 = tmp_path/ "output1.h5mu"
+    run_component(["--input", write_temp_h5mu(h5mu),
+                   "--modality", "mod1",
+                   "--obsm_key", "obsm_key",
+                   "--output", output_run_1
+                   ])
+    output_data_run_1 = read_h5mu(output_run_1)
+    output_data_run_1.mod["mod1"].obsm = \
+        {"obsm_key": pd.DataFrame([["dolor", "amet"], ["jommeke", "filiberke"]],
+                                  index=output_data_run_1.mod["mod1"].obs_names,
+                                  columns=["obsm_col1", "obsm_col2"])}
+    
+    output_run_2 = tmp_path / "output2.h5mu"
+    input_run_2 = write_temp_h5mu(output_data_run_1)
+    run_component(["--input", input_run_2,
+                   "--modality", "mod1",
+                   "--obsm_key", "obsm_key",
+                   "--output", output_run_2
+                   ])
+    assert output_run_2.is_file(), "Some output file must have been created."
+    output_data = read_h5mu(output_run_2)
+    pd.testing.assert_index_equal(output_data.mod['mod1'].obs.index, pd.Index(['obs1', 'obs2']))
+    pd.testing.assert_index_equal(output_data.mod['mod1'].obs.columns, 
+                                  pd.Index(['Obs', 'sample_id', 'obsm_key_obsm_col1', 'obsm_key_obsm_col2']))
+    assert 'obsm_key' not in output_data.mod['mod1'].obsm
 
 if __name__ == '__main__':
-    exit(pytest.main([__file__]))
+    exit(pytest.main([__file__, "--log_cli_level", "DEBUG"]))


### PR DESCRIPTION
## Changelog

`move_obsm_to_obs`: fix setting output columns when they already exist.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!