### PR TITLE
Change separator for arguments with multiple input from `:` to `;`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,7 +142,7 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 * `move_obsm_to_obs`: fix setting output columns when they already exist (PR #690).
 
-* Change separator for arguments with multiple input from `:` to `;` (PR #700). This is in theory a breaking change since arguments like `--input foo:bar` would now need to be written as `--input foo;bar`. However, this way of writing arguments is not expected to be used in practice.
+* Change separator for arguments with multiple input from `:` to `;` (PR #700). This is in theory a breaking change since arguments like `--input "foo:bar"` would now need to be written as `--input "foo;bar"`. However, this way of writing arguments is not expected to be used in practice.
 
 # openpipelines 0.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## BREAKING CHANGES
 
+* Change separator for arguments with multiple inputs from `:` to `;` (PR #700). Now, _all_ arguments with `multiple: true` will use `;` as the separator.
+  This change was made to be able to deal with file paths that contain `:`, e.g. `s3://my-bucket/my:file.txt`. Furthermore, the `;` separator will become
+  the default separator for all arguments with `multiple: true` in Viash >= 0.9.0.
+
 * This project now uses viash version 0.8.3 to build components and workflows. Changes related to this version update should
   be _mostly_ backwards compatible with respect to the results and execution of the pipelines. From a development perspective,
   drastic updates have been made to the developemt workflow.
@@ -63,6 +67,7 @@
       - `--filter_with_hvg_flavor` became `--highly_variable_features_flavor`
  
 * Renamed `obsm_metrics` to `uns_metrics` for the `cellranger_mapping` workflow because the cellranger metrics are stored in `.uns` and not `.obsm` (PR #610).
+
 
 ## MAJOR CHANGES
 
@@ -141,8 +146,6 @@ of a split multimodal files. The modalities in the list must be unique and after
 * `qc/calculate_qc_metrics`: Resolved an issue where statistics based on the input columns selected with `--var_qc_metrics` were incorrect when these input columns were encoded in `pd.BooleanDtype()` (PR #685).
 
 * `move_obsm_to_obs`: fix setting output columns when they already exist (PR #690).
-
-* Change separator for arguments with multiple input from `:` to `;` (PR #700). This is in theory a breaking change since arguments like `--input "foo:bar"` would now need to be written as `--input "foo;bar"`. However, this way of writing arguments is not expected to be used in practice.
 
 # openpipelines 0.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 ## BUG FIXES
 
-* `transform/log1p`: fix `--input_layer` argument not functionning (PR #678). 
+* `transform/log1p`: fix `--input_layer` argument not functioning (PR #678). 
 
 * `dataflow/concat` and `dataflow/concatenate_h5mu`: Fix an issue where using `--mode move` on samples with non-overlapping features would cause `var_names` to become unaligned to the data (PR #653).   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 * `move_obsm_to_obs`: fix setting output columns when they already exist (PR #690).
 
+* Change separator for arguments with multiple input from `:` to `;` (PR #700). This is in theory a breaking change since arguments like `--input foo:bar` would now need to be written as `--input foo;bar`. However, this way of writing arguments is not expected to be used in practice.
+
 # openpipelines 0.12.1
 
 ## BUG FIXES

--- a/_viash.yaml
+++ b/_viash.yaml
@@ -6,6 +6,8 @@ target: target
 config_mods: |
   .functionality.version := 'dev'
   .functionality.requirements.commands := ['ps']
+  .functionality.arguments[.multiple == true].multiple_sep := ";"
+  .functionality.argument_groups[true].arguments[.multiple == true].multiple_sep := ";"
   .platforms[.type == 'docker'].namespace_separator := '_'
   .platforms[.type == 'docker'].target_registry := 'ghcr.io'
   .platforms[.type == 'docker'].target_organization := 'openpipelines-bio'

--- a/src/dataflow/concat/config.vsh.yaml
+++ b/src/dataflow/concat/config.vsh.yaml
@@ -12,14 +12,12 @@ functionality:
       alternatives: ["-i"]
       type: file
       multiple: true
-      multiple_sep: ','
       description: Paths to the different samples to be concatenated.
       required: true
       example: sample_paths
     - name: "--input_id"
       type: string
       multiple: true
-      multiple_sep: ','
       description: |
         Names of the different samples that have to be concatenated.  Must be specified when using '--mode move'.
         In this case, the ids will be used for the columns names of the dataframes registring the conflicts.

--- a/src/dataflow/concatenate_h5mu/config.vsh.yaml
+++ b/src/dataflow/concatenate_h5mu/config.vsh.yaml
@@ -11,14 +11,12 @@ functionality:
       alternatives: ["-i"]
       type: file
       multiple: true
-      multiple_sep: ','
       description: Paths to the different samples to be concatenated.
       required: true
       example: sample_paths
     - name: "--input_id"
       type: string
       multiple: true
-      multiple_sep: ','
       description: |
         Names of the different samples that have to be concatenated.  Must be specified when using '--mode move'.
         In this case, the ids will be used for the columns names of the dataframes registring the conflicts.

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -346,7 +346,7 @@ def test_resolve_annotation_conflict_missing_column(run_component, copied_mudata
     original_data_path = tmp_path / f"{uuid.uuid4().hex}.h5mu"
     original_data.write_h5mu(original_data_path)
     run_component([
-        "--input_id", "mouse;human,sample_without_column",
+        "--input_id", "mouse;human;sample_without_column",
         "--input", tempfile_input1,
         "--input", tempfile_input2,
         "--input", original_data_path,

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -120,7 +120,7 @@ def test_concatenate_samples_with_same_observation_ids_raises(run_component):
     """
     with pytest.raises(subprocess.CalledProcessError) as err:
         run_component([
-                "--input_id", "mouse,mouse2",
+                "--input_id", "mouse;mouse2",
                 "--input", input_sample1_file,
                 "--input", input_sample1_file,
                 "--output", "concat.h5mu",
@@ -143,7 +143,7 @@ def test_concat_different_var_columns_per_sample(run_component, mudata_without_g
     """
     [sample1_without_genome,] = mudata_without_genome
     run_component([
-            "--input_id", "mouse,human",
+            "--input_id", "mouse;human",
             "--input", sample1_without_genome,
             "--input", input_sample2_file,
             "--output", "concat.h5mu",
@@ -190,7 +190,7 @@ def test_concat_different_columns_per_modality(run_component, mudata_without_gen
     sample1_without_genome, sample2_without_genome = mudata_without_genome
 
     run_component([
-            "--input_id", "mouse,human",
+            "--input_id", "mouse;human",
             "--input", sample1_without_genome,
             "--input", sample2_without_genome,
             "--output", "concat.h5mu",
@@ -238,7 +238,7 @@ def test_concat_different_columns_per_modality_and_per_sample(run_component, mud
 
     [sample_1_without_genome, ] = mudata_without_genome
     run_component([
-        "--input_id", "mouse,human",
+        "--input_id", "mouse;human",
         "--input", sample_1_without_genome,
         "--input", input_sample2_file,
         "--output", "concat.h5mu",
@@ -289,7 +289,7 @@ def test_concat_remove_na(run_component, copied_mudata_with_extra_annotation_col
     """
     tempfile_input1, tempfile_input2 = copied_mudata_with_extra_annotation_column
     run_component([
-        "--input_id", "mouse,human",
+        "--input_id", "mouse;human",
         "--input", tempfile_input1,
         "--input", tempfile_input2,
         "--output", "concat.h5mu",
@@ -321,7 +321,7 @@ def test_concat_dtypes(run_component, copied_mudata_with_extra_annotation_column
     """
     tempfile_input1, tempfile_input2 = copied_mudata_with_extra_annotation_column
     run_component([
-        "--input_id", "mouse,human",
+        "--input_id", "mouse;human",
         "--input", tempfile_input1,
         "--input", tempfile_input2,
         "--output", "concat.h5mu",
@@ -346,7 +346,7 @@ def test_resolve_annotation_conflict_missing_column(run_component, copied_mudata
     original_data_path = tmp_path / f"{uuid.uuid4().hex}.h5mu"
     original_data.write_h5mu(original_data_path)
     run_component([
-        "--input_id", "mouse,human,sample_without_column",
+        "--input_id", "mouse;human,sample_without_column",
         "--input", tempfile_input1,
         "--input", tempfile_input2,
         "--input", original_data_path,
@@ -373,7 +373,7 @@ def test_mode_move(run_component, tmp_path):
     input1.write(tempfile_input1.name)
     input2.write(tempfile_input2.name)
     run_component([
-        "--input_id", "mouse,human",
+        "--input_id", "mouse;human",
         "--input", tempfile_input1.name,
         "--input", tempfile_input2.name,
         "--output", "concat.h5mu",
@@ -420,7 +420,7 @@ def test_concat_invalid_h5_error_includes_path(run_component, tmp_path):
     empty_file.touch()
     with pytest.raises(subprocess.CalledProcessError) as err:
         run_component([
-                "--input_id", "mouse,empty",
+                "--input_id", "mouse;empty",
                 "--input", input_sample1_file,
                 "--input", empty_file,
                 "--output", "concat.h5mu",
@@ -440,7 +440,7 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome,
     """
     [sample1_without_genome,] = mudata_without_genome
     run_component([
-            "--input_id", "mouse,human",
+            "--input_id", "mouse;human",
             "--input", sample1_without_genome,
             "--input", input_sample2_file,
             "--output", "concat.h5mu",

--- a/src/dataflow/merge/config.vsh.yml
+++ b/src/dataflow/merge/config.vsh.yml
@@ -11,7 +11,6 @@ functionality:
       alternatives: ["-i"]
       type: file
       multiple: true
-      multiple_sep: ','
       description: Paths to the single-modality .h5mu files that need to be combined
       required: true
       default: sample_paths

--- a/src/download/sync_test_resources/script.sh
+++ b/src/download/sync_test_resources/script.sh
@@ -20,7 +20,7 @@ if [ "$par_delete" == "true" ]; then
 fi
 
 if [ ! -z ${par_exclude+x} ]; then
-  IFS=":"
+  IFS=";"
   for var in $par_exclude; do
     unset IFS
     extra_params+=( "--exclude" "$var" )

--- a/src/genetic_demux/bcftools/config.vsh.yaml
+++ b/src/genetic_demux/bcftools/config.vsh.yaml
@@ -10,7 +10,6 @@ functionality:
       type: file
       required: true
       multiple: true
-      multiple_sep: ","
       description: VCF files, must have the same sample columns appearing in the same order.
     - name: "--concat"
       type: boolean_true

--- a/src/genetic_demux/bcftools/script.sh
+++ b/src/genetic_demux/bcftools/script.sh
@@ -3,7 +3,7 @@ if [ ! -d "$par_output" ]; then
   mkdir -p $par_output
 fi
 
-IFS="," read -a vcf_list <<< $par_vcf
+IFS=";" read -a vcf_list <<< $par_vcf
 
 
 if [ "$par_concat" = true ] && [ "$par_filter" = true ] ; then

--- a/src/genetic_demux/bcftools/test.sh
+++ b/src/genetic_demux/bcftools/test.sh
@@ -4,7 +4,8 @@ set -ex
 
 echo ">>> Running executable"
 $meta_executable \
-    --vcf "$meta_resources_dir/demuxafy_test_data/test_dataset_chr1_2.vcf,$meta_resources_dir/demuxafy_test_data/test_dataset_chr3_4.vcf" \
+    --vcf "$meta_resources_dir/demuxafy_test_data/test_dataset_chr1_2.vcf" \
+    --vcf "$meta_resources_dir/demuxafy_test_data/test_dataset_chr3_4.vcf" \
     --concat --filter \
     --output bcftools_result/
 

--- a/src/labels_transfer/api/common_arguments.yaml
+++ b/src/labels_transfer/api/common_arguments.yaml
@@ -86,7 +86,6 @@
           default: [ ann_level_1, ann_level_2, ann_level_3, ann_level_4, ann_level_5, ann_finest_level ]
           required: false
           multiple: true
-          multiple_sep: ","
           description: The `.obs` key of the target labels to tranfer.
     - name: Outputs
       arguments:

--- a/src/mapping/bd_rhapsody/config.vsh.yaml
+++ b/src/mapping/bd_rhapsody/config.vsh.yaml
@@ -37,7 +37,6 @@ functionality:
           description: Path to your read files in the FASTQ.GZ format. You may specify as many R1/R2 read pairs as you want.
           required: true
           multiple: true
-          multiple_sep: ';'
           example: input.fastq.gz
         - name: "--reference"
           type: file
@@ -46,7 +45,6 @@ functionality:
           example: "reference_genome.tar.gz|reference.fasta"
           required: true
           multiple: true
-          multiple_sep: ';'
         - name: "--transcriptome_annotation"
           type: file
           alternatives: [-t]
@@ -58,14 +56,12 @@ functionality:
           description: Path to the AbSeq reference file in FASTA format. Only needed if BD AbSeq Ab-Oligos are used.
           example: "abseq_reference.fasta"
           multiple: true
-          multiple_sep: ';'
         - name: "--supplemental_reference"
           type: file
           alternatives: [-s]
           description: "Path to the supplemental reference file in FASTA format. Only needed if there are additional transgene sequences used in the experiment (only for `--mode wta`)."
           example: "supplemental_reference.fasta"
           multiple: true
-          multiple_sep: ';'
         - name: "--sample_prefix"
           type: string
           description: "Specify a run name to use as the output file base name. Use only letters, numbers, or hyphens. Do not use special characters or spaces."

--- a/src/mapping/cellranger_count/config.vsh.yaml
+++ b/src/mapping/cellranger_count/config.vsh.yaml
@@ -16,7 +16,6 @@ functionality:
           name: --input
           required: true
           multiple: true
-          multiple_sep: ";"
           example: [ "sample_S1_L001_R1_001.fastq.gz", "sample_S1_L001_R2_001.fastq.gz" ]
           description: The fastq.gz files to align. Can also be a single directory containing fastq.gz files.
         - type: file

--- a/src/mapping/cellranger_multi/config.vsh.yaml
+++ b/src/mapping/cellranger_multi/config.vsh.yaml
@@ -80,6 +80,7 @@ functionality:
         #   example: "..."
         #   multiple: true
         #        - type: string
+        - type: string
           name: --library_lanes
           required: false
           description: Lanes associated with this sample. Defaults to using all lanes.

--- a/src/mapping/cellranger_multi/config.vsh.yaml
+++ b/src/mapping/cellranger_multi/config.vsh.yaml
@@ -20,7 +20,6 @@ functionality:
             `[Sample Name]_S[Sample Index]_L00[Lane Number]_[Read Type]_001.fastq.gz`
           example: [ mysample_S1_L001_R1_001.fastq.gz, mysample_S1_L001_R2_001.fastq.gz ]
           multiple: true
-          multiple_sep: ";"
 
         - name: "--gex_reference"
           type: file
@@ -57,7 +56,6 @@ functionality:
           description: The Illumina sample name to analyze. This must exactly match the 'Sample Name' part of the FASTQ files specified in the `--input` argument.
           example: ["mysample1"]
           multiple: true
-          multiple_sep: ";"
         - type: string
           name: --library_type
           required: true
@@ -68,14 +66,12 @@ functionality:
           # choices: [ "Gene Expression", "VDJ", "VDJ-T", "VDJ-B", "Antibody Capture", "CRISPR Guide Capture", "Multiplexing Capture" ]
           example: "Gene Expression"
           multiple: true
-          multiple_sep: ";"
         - type: string
           name: --library_subsample
           required: false
           description: Optional. The rate at which reads from the provided FASTQ files are sampled. Must be strictly greater than 0 and less than or equal to 1.
           example: "0.5"
           multiple: true
-          multiple_sep: ";"
         # NOTE: physical_library_id was not included because documentation
         # specifies that users don't typically need to interact with it.
         # - type: string
@@ -83,14 +79,12 @@ functionality:
         #   description:  Library type. NOTE: by default, the library type is detected automatically based on specified feature_types (recommended mode). Users typically do not need to include the physical_library_id column in the CSV file.
         #   example: "..."
         #   multiple: true
-        #   multiple_sep: ";"
-        - type: string
+        #        - type: string
           name: --library_lanes
           required: false
           description: Lanes associated with this sample. Defaults to using all lanes.
           example: "1-4"
           multiple: true
-          multiple_sep: ";"
 
     - name: Gene expression arguments
       description: Arguments relevant to the analysis of gene expression data.

--- a/src/mapping/htseq_count/config.vsh.yaml
+++ b/src/mapping/htseq_count/config.vsh.yaml
@@ -21,7 +21,6 @@ functionality:
           description: Path to the SAM/BAM files containing the mapped reads.
           example: [ mysample1.BAM, mysample2.BAM ]
           multiple: true
-          multiple_sep: ";"
           info:
             orig_arg: samfilenames
         - type: file
@@ -58,7 +57,6 @@ functionality:
           direction: output
           required: false
           multiple: true
-          multiple_sep: ";"
           info:
             orig_arg: --samout
         - type: string
@@ -117,7 +115,6 @@ functionality:
             times: in that case, the combination of all attributes separated by colons (:) will be used
             as a unique identifier, e.g. for exons you might use -i gene_id -i exon_number.
           multiple: true
-          multiple_sep: ":"
           info:
             orig_arg: --idattr
         - name: --additional_attributes
@@ -128,7 +125,6 @@ functionality:
             for more than one additional attribute. These attributes are only used as annotations in the
             output, while the determination of how the counts are added together is done based on option -i.
           multiple: true
-          multiple_sep: ":"
           info:
             orig_arg: --additional-attr
         - name: --add_chromosome_info

--- a/src/mapping/htseq_count_to_h5mu/config.vsh.yaml
+++ b/src/mapping/htseq_count_to_h5mu/config.vsh.yaml
@@ -17,14 +17,12 @@ functionality:
           description: The obs index for the counts
           example: foo
           multiple: true
-          multiple_sep: ;
         - type: file
           name: --input_counts
           required: true
           description: The counts as a TSV file as output by HTSeq.
           example: counts.tsv
           multiple: true
-          multiple_sep: ;
         - type: file
           name: --reference
           required: true

--- a/src/mapping/multi_star/arguments_htseq.yaml
+++ b/src/mapping/multi_star/arguments_htseq.yaml
@@ -41,7 +41,6 @@ argument_groups:
           times: in that case, the combination of all attributes separated by colons (:) will be used
           as a unique identifier, e.g. for exons you might use -i gene_id -i exon_number.
         multiple: true
-        multiple_sep: ":"
         info:
           step: htseq
           orig_arg: --idattr
@@ -53,7 +52,6 @@ argument_groups:
           for more than one additional attribute. These attributes are only used as annotations in the
           output, while the determination of how the counts are added together is done based on option -i.
         multiple: true
-        multiple_sep: ":"
         info:
           step: htseq
           orig_arg: --additional-attr

--- a/src/mapping/multi_star/arguments_star.yaml
+++ b/src/mapping/multi_star/arguments_star.yaml
@@ -20,7 +20,6 @@ argument_groups:
       step: star
       orig_arg: --genomeFastaFiles
     multiple: yes
-    multiple_sep: ;
 - name: Splice Junctions Database
   arguments:
   - name: --sjdbFileChrStartEnd
@@ -32,7 +31,6 @@ argument_groups:
       step: star
       orig_arg: --sjdbFileChrStartEnd
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbGTFfile
     type: file
     description: path to the GTF file with annotations
@@ -77,7 +75,6 @@ argument_groups:
       orig_arg: --sjdbGTFtagExonParentGeneName
     example: gene_name
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbGTFtagExonParentGeneType
     type: string
     description: GTF attribute name for parent gene type
@@ -88,7 +85,6 @@ argument_groups:
     - gene_type
     - gene_biotype
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbOverhang
     type: integer
     description: length of the donor/acceptor sequence on each side of the junctions,
@@ -150,7 +146,6 @@ argument_groups:
       orig_arg: --readFilesSAMattrKeep
     example: All
     multiple: yes
-    multiple_sep: ;
   - name: --readFilesManifest
     type: file
     description: |-
@@ -181,7 +176,6 @@ argument_groups:
       step: star
       orig_arg: --readFilesCommand
     multiple: yes
-    multiple_sep: ;
   - name: --readMapNumber
     type: integer
     description: |-
@@ -209,7 +203,6 @@ argument_groups:
       orig_arg: --readNameSeparator
     example: /
     multiple: yes
-    multiple_sep: ;
   - name: --readQualityScoreBase
     type: integer
     description: number to be subtracted from the ASCII code to get Phred quality
@@ -241,7 +234,6 @@ argument_groups:
       orig_arg: --clip3pNbases
     example: 0
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAdapterSeq
     type: string
     description: |-
@@ -252,7 +244,6 @@ argument_groups:
       step: star
       orig_arg: --clip3pAdapterSeq
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAdapterMMp
     type: double
     description: max proportion of mismatches for 3p adapter clipping for each mate.  If
@@ -262,7 +253,6 @@ argument_groups:
       orig_arg: --clip3pAdapterMMp
     example: 0.1
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAfterAdapterNbases
     type: integer
     description: number of bases to clip from 3p of each mate after the adapter clipping.
@@ -272,7 +262,6 @@ argument_groups:
       orig_arg: --clip3pAfterAdapterNbases
     example: 0
     multiple: yes
-    multiple_sep: ;
   - name: --clip5pNbases
     type: integer
     description: number(s) of bases to clip from 5p of each mate. If one value is
@@ -282,7 +271,6 @@ argument_groups:
       orig_arg: --clip5pNbases
     example: 0
     multiple: yes
-    multiple_sep: ;
 - name: Limits
   arguments:
   - name: --limitGenomeGenerateRAM
@@ -302,7 +290,6 @@ argument_groups:
     - 30000000
     - 50000000
     multiple: yes
-    multiple_sep: ;
   - name: --limitOutSAMoneReadBytes
     type: long
     description: 'max size of the SAM record (bytes) for one read. Recommended value:
@@ -472,7 +459,6 @@ argument_groups:
       orig_arg: --outSAMattributes
     example: Standard
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMattrIHstart
     type: integer
     description: start value for the IH attribute. 0 may be required by some downstream
@@ -495,7 +481,6 @@ argument_groups:
       step: star
       orig_arg: --outSAMunmapped
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMorder
     type: string
     description: |-
@@ -567,7 +552,6 @@ argument_groups:
       step: star
       orig_arg: --outSAMattrRGline
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderHD
     type: string
     description: '@HD (header) line of the SAM header'
@@ -575,7 +559,6 @@ argument_groups:
       step: star
       orig_arg: --outSAMheaderHD
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderPG
     type: string
     description: extra @PG (software) line of the SAM header (in addition to STAR)
@@ -583,7 +566,6 @@ argument_groups:
       step: star
       orig_arg: --outSAMheaderPG
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderCommentFile
     type: string
     description: path to the file with @CO (comment) lines of the SAM header
@@ -601,7 +583,6 @@ argument_groups:
       step: star
       orig_arg: --outSAMfilter
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMmultNmax
     type: integer
     description: |-
@@ -684,7 +665,6 @@ argument_groups:
       step: star
       orig_arg: --outWigType
     multiple: yes
-    multiple_sep: ;
   - name: --outWigStrand
     type: string
     description: |-
@@ -863,7 +843,6 @@ argument_groups:
     - 12
     - 12
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterCountUniqueMin
     type: integer
     description: |-
@@ -880,7 +859,6 @@ argument_groups:
     - 1
     - 1
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterCountTotalMin
     type: integer
     description: |-
@@ -897,7 +875,6 @@ argument_groups:
     - 1
     - 1
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterDistToOtherSJmin
     type: integer
     description: |-
@@ -913,7 +890,6 @@ argument_groups:
     - 5
     - 10
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterIntronMaxVsReadN
     type: integer
     description: |-
@@ -929,7 +905,6 @@ argument_groups:
     - 100000
     - 200000
     multiple: yes
-    multiple_sep: ;
 - name: Scoring
   arguments:
   - name: --scoreGap
@@ -1119,7 +1094,6 @@ argument_groups:
     - 0
     - 0
     multiple: yes
-    multiple_sep: ;
   - name: --alignSJDBoverhangMin
     type: integer
     description: minimum overhang (i.e. block size) for annotated (sjdb) spliced alignments
@@ -1293,7 +1267,6 @@ argument_groups:
       orig_arg: --chimOutType
     example: Junctions
     multiple: yes
-    multiple_sep: ;
   - name: --chimSegmentMin
     type: integer
     description: minimum length of chimeric segment length, if ==0, no chimeric output
@@ -1357,7 +1330,6 @@ argument_groups:
       orig_arg: --chimFilter
     example: banGenomicN
     multiple: yes
-    multiple_sep: ;
   - name: --chimMainSegmentMultNmax
     type: integer
     description: maximum number of multi-alignments for the main chimeric segment.
@@ -1418,7 +1390,6 @@ argument_groups:
       step: star
       orig_arg: --quantMode
     multiple: yes
-    multiple_sep: ;
   - name: --quantTranscriptomeBAMcompression
     type: integer
     description: |-
@@ -1489,7 +1460,6 @@ argument_groups:
       step: star
       orig_arg: --soloType
     multiple: yes
-    multiple_sep: ;
   - name: --soloCBwhitelist
     type: string
     description: |-
@@ -1500,7 +1470,6 @@ argument_groups:
       step: star
       orig_arg: --soloCBwhitelist
     multiple: yes
-    multiple_sep: ;
   - name: --soloCBstart
     type: integer
     description: cell barcode start base
@@ -1568,7 +1537,6 @@ argument_groups:
       step: star
       orig_arg: --soloCBposition
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIposition
     type: string
     description: |-
@@ -1620,7 +1588,6 @@ argument_groups:
       step: star
       orig_arg: --soloInputSAMattrBarcodeSeq
     multiple: yes
-    multiple_sep: ;
   - name: --soloInputSAMattrBarcodeQual
     type: string
     description: |-
@@ -1632,7 +1599,6 @@ argument_groups:
       step: star
       orig_arg: --soloInputSAMattrBarcodeQual
     multiple: yes
-    multiple_sep: ;
   - name: --soloStrand
     type: string
     description: |-
@@ -1660,7 +1626,6 @@ argument_groups:
       orig_arg: --soloFeatures
     example: Gene
     multiple: yes
-    multiple_sep: ;
   - name: --soloMultiMappers
     type: string
     description: |-
@@ -1676,7 +1641,6 @@ argument_groups:
       orig_arg: --soloMultiMappers
     example: Unique
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIdedup
     type: string
     description: |-
@@ -1693,7 +1657,6 @@ argument_groups:
       orig_arg: --soloUMIdedup
     example: 1MM_All
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIfiltering
     type: string
     description: |-
@@ -1708,7 +1671,6 @@ argument_groups:
       step: star
       orig_arg: --soloUMIfiltering
     multiple: yes
-    multiple_sep: ;
   - name: --soloOutFileNames
     type: string
     description: |-
@@ -1724,7 +1686,6 @@ argument_groups:
     - barcodes.tsv
     - matrix.mtx
     multiple: yes
-    multiple_sep: ;
   - name: --soloCellFilter
     type: string
     description: |-
@@ -1747,7 +1708,6 @@ argument_groups:
     - '0.99'
     - '10'
     multiple: yes
-    multiple_sep: ;
   - name: --soloOutFormatFeaturesGeneField3
     type: string
     description: field 3 in the Gene features.tsv file. If "-", then no 3rd field
@@ -1757,7 +1717,6 @@ argument_groups:
       orig_arg: --soloOutFormatFeaturesGeneField3
     example: Gene Expression
     multiple: yes
-    multiple_sep: ;
   - name: --soloCellReadStats
     type: string
     description: |-

--- a/src/mapping/multi_star/config.vsh.yaml
+++ b/src/mapping/multi_star/config.vsh.yaml
@@ -19,21 +19,18 @@ functionality:
           description: The ID of the sample being processed. This vector should have the same length as the `--input_r1` argument.
           example: [ mysample, mysample ]
           multiple: true
-          multiple_sep: ";"
         - type: file
           name: --input_r1
           required: true
           description: Paths to the sequences to be mapped. If using Illumina paired-end reads, only the R1 files should be passed.
           example: [ mysample_S1_L001_R1_001.fastq.gz, mysample_S1_L002_R1_001.fastq.gz ]
           multiple: true
-          multiple_sep: ";"
         - type: file
           name: --input_r2
           required: false
           description: Paths to the sequences to be mapped. If using Illumina paired-end reads, only the R2 files should be passed.
           example: [ mysample_S1_L001_R2_001.fastq.gz, mysample_S1_L002_R2_001.fastq.gz ]
           multiple: true
-          multiple_sep: ";"
         - type: file
           name: --reference_index
           alternatives: --genomeDir

--- a/src/mapping/star_align/argument_groups.yaml
+++ b/src/mapping/star_align/argument_groups.yaml
@@ -25,14 +25,12 @@ argument_groups:
 
       Required for the genome generation (--runMode genomeGenerate). Can also be used in the mapping (--runMode alignReads) to add extra (new) sequences to the genome (e.g. spike-ins).
     multiple: yes
-    multiple_sep: ;
   - name: --genomeFileSizes
     type: integer
     description: genome files exact sizes in bytes. Typically, this should not be
       defined by the user.
     example: 0
     multiple: yes
-    multiple_sep: ;
   - name: --genomeTransformOutput
     type: string
     description: |-
@@ -42,7 +40,6 @@ argument_groups:
       - SJ      ... splice junctions (SJ.out.tab)
       - None    ... no transformation of the output
     multiple: yes
-    multiple_sep: ;
   - name: --genomeChrSetMitochondrial
     type: string
     description: names of the mitochondrial chromosomes. Presently only used for STARsolo
@@ -52,7 +49,6 @@ argument_groups:
     - M
     - MT
     multiple: yes
-    multiple_sep: ;
 - name: Splice Junctions Database
   arguments:
   - name: --sjdbFileChrStartEnd
@@ -61,7 +57,6 @@ argument_groups:
       end <tab> strand) for the splice junction introns. Multiple files can be supplied
       and will be concatenated.
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbGTFfile
     type: file
     description: path to the GTF file with annotations
@@ -88,7 +83,6 @@ argument_groups:
     description: GTF attribute name for parent gene name
     example: gene_name
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbGTFtagExonParentGeneType
     type: string
     description: GTF attribute name for parent gene type
@@ -96,7 +90,6 @@ argument_groups:
     - gene_type
     - gene_biotype
     multiple: yes
-    multiple_sep: ;
   - name: --sjdbOverhang
     type: integer
     description: length of the donor/acceptor sequence on each side of the junctions,
@@ -140,7 +133,6 @@ argument_groups:
       - None    ... do not keep any tags
     example: All
     multiple: yes
-    multiple_sep: ;
   - name: --readFilesManifest
     type: file
     description: |-
@@ -162,7 +154,6 @@ argument_groups:
 
       For example: zcat - to uncompress .gz files, bzcat - to uncompress .bz2 files, etc.
     multiple: yes
-    multiple_sep: ;
   - name: --readMapNumber
     type: integer
     description: |-
@@ -181,7 +172,6 @@ argument_groups:
       in output (read name after space is always trimmed)
     example: /
     multiple: yes
-    multiple_sep: ;
   - name: --readQualityScoreBase
     type: integer
     description: number to be subtracted from the ASCII code to get Phred quality
@@ -204,7 +194,6 @@ argument_groups:
       given, it will be assumed the same for both mates.
     example: 0
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAdapterSeq
     type: string
     description: |-
@@ -212,28 +201,24 @@ argument_groups:
 
       - polyA ... polyA sequence with the length equal to read length
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAdapterMMp
     type: double
     description: max proportion of mismatches for 3p adapter clipping for each mate.  If
       one value is given, it will be assumed the same for both mates.
     example: 0.1
     multiple: yes
-    multiple_sep: ;
   - name: --clip3pAfterAdapterNbases
     type: integer
     description: number of bases to clip from 3p of each mate after the adapter clipping.
       If one value is given, it will be assumed the same for both mates.
     example: 0
     multiple: yes
-    multiple_sep: ;
   - name: --clip5pNbases
     type: integer
     description: number(s) of bases to clip from 5p of each mate. If one value is
       given, it will be assumed the same for both mates.
     example: 0
     multiple: yes
-    multiple_sep: ;
 - name: Limits
   arguments:
   - name: --limitGenomeGenerateRAM
@@ -247,7 +232,6 @@ argument_groups:
     - 30000000
     - 50000000
     multiple: yes
-    multiple_sep: ;
   - name: --limitOutSAMoneReadBytes
     type: long
     description: 'max size of the SAM record (bytes) for one read. Recommended value:
@@ -333,7 +317,6 @@ argument_groups:
       - SortedByCoordinate ... sorted by coordinate. This option will allocate extra memory for sorting which can be specified by --limitBAMsortRAM.
     example: SAM
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMmode
     type: string
     description: |-
@@ -390,7 +373,6 @@ argument_groups:
       - vR          ... read coordinate of the variant.
     example: Standard
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMattrIHstart
     type: integer
     description: start value for the IH attribute. 0 may be required by some downstream
@@ -407,7 +389,6 @@ argument_groups:
       2nd word:
       - KeepPairs ... record unmapped mate for each alignment, and, in case of unsorted output, keep it adjacent to its mapped mate. Only affects multi-mapping reads.
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMorder
     type: string
     description: |-
@@ -458,17 +439,14 @@ argument_groups:
       Comma separated RG lines correspons to different (comma separated) input files in --readFilesIn. Commas have to be surrounded by spaces, e.g.
       --outSAMattrRGline ID:xxx , ID:zzz "DS:z z" , ID:yyy DS:yyyy
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderHD
     type: string
     description: '@HD (header) line of the SAM header'
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderPG
     type: string
     description: extra @PG (software) line of the SAM header (in addition to STAR)
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMheaderCommentFile
     type: string
     description: path to the file with @CO (comment) lines of the SAM header
@@ -480,7 +458,6 @@ argument_groups:
       - KeepOnlyAddedReferences ... only keep the reads for which all alignments are to the extra reference sequences added with --genomeFastaFiles at the mapping stage.
       - KeepAllAddedReferences ...  keep all alignments to the extra reference sequences added with --genomeFastaFiles at the mapping stage.
     multiple: yes
-    multiple_sep: ;
   - name: --outSAMmultNmax
     type: integer
     description: |-
@@ -539,7 +516,6 @@ argument_groups:
       - read1_5p   ... signal from only 5' of the 1st read, useful for CAGE/RAMPAGE etc
       - read2      ... signal from only 2nd read
     multiple: yes
-    multiple_sep: ;
   - name: --outWigStrand
     type: string
     description: |-
@@ -664,7 +640,6 @@ argument_groups:
     - 12
     - 12
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterCountUniqueMin
     type: integer
     description: |-
@@ -678,7 +653,6 @@ argument_groups:
     - 1
     - 1
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterCountTotalMin
     type: integer
     description: |-
@@ -692,7 +666,6 @@ argument_groups:
     - 1
     - 1
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterDistToOtherSJmin
     type: integer
     description: |-
@@ -705,7 +678,6 @@ argument_groups:
     - 5
     - 10
     multiple: yes
-    multiple_sep: ;
   - name: --outSJfilterIntronMaxVsReadN
     type: integer
     description: |-
@@ -718,7 +690,6 @@ argument_groups:
     - 100000
     - 200000
     multiple: yes
-    multiple_sep: ;
 - name: Scoring
   arguments:
   - name: --scoreGap
@@ -836,7 +807,6 @@ argument_groups:
     - 0
     - 0
     multiple: yes
-    multiple_sep: ;
   - name: --alignSJDBoverhangMin
     type: integer
     description: minimum overhang (i.e. block size) for annotated (sjdb) spliced alignments
@@ -953,7 +923,6 @@ argument_groups:
       - WithinBAM SoftClip  ... soft-clipping in the CIGAR for supplemental chimeric alignments
     example: Junctions
     multiple: yes
-    multiple_sep: ;
   - name: --chimSegmentMin
     type: integer
     description: minimum length of chimeric segment length, if ==0, no chimeric output
@@ -993,7 +962,6 @@ argument_groups:
       - banGenomicN ... Ns are not allowed in the genome sequence around the chimeric junction
     example: banGenomicN
     multiple: yes
-    multiple_sep: ;
   - name: --chimMainSegmentMultNmax
     type: integer
     description: maximum number of multi-alignments for the main chimeric segment.
@@ -1036,7 +1004,6 @@ argument_groups:
       - TranscriptomeSAM ... output SAM/BAM alignments to transcriptome into a separate file
       - GeneCounts       ... count reads per gene
     multiple: yes
-    multiple_sep: ;
   - name: --quantTranscriptomeBAMcompression
     type: integer
     description: |-
@@ -1089,7 +1056,6 @@ argument_groups:
       - CB_samTagOut    ... output Cell Barcode as CR and/or CB SAm tag. No UMI counting. --readFilesIn cDNA_read1 [cDNA_read2 if paired-end] CellBarcode_read . Requires --outSAMtype BAM Unsorted [and/or SortedByCoordinate]
       - SmartSeq        ... Smart-seq: each cell in a separate FASTQ (paired- or single-end), barcodes are corresponding read-groups, no UMI sequences, alignments deduplicated according to alignment start and end (after extending soft-clipped bases)
     multiple: yes
-    multiple_sep: ;
   - name: --soloCBwhitelist
     type: string
     description: |-
@@ -1097,7 +1063,6 @@ argument_groups:
 
       - None            ... no whitelist: all cell barcodes are allowed
     multiple: yes
-    multiple_sep: ;
   - name: --soloCBstart
     type: integer
     description: cell barcode start base
@@ -1144,7 +1109,6 @@ argument_groups:
       Example: inDrop (Zilionis et al, Nat. Protocols, 2017):
       --soloCBposition  0_0_2_-1  3_1_3_8
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIposition
     type: string
     description: |-
@@ -1181,7 +1145,6 @@ argument_groups:
       For instance, for 10X CellRanger or STARsolo BAMs, use --soloInputSAMattrBarcodeSeq CR UR .
       This parameter is required when running STARsolo with input from SAM.
     multiple: yes
-    multiple_sep: ;
   - name: --soloInputSAMattrBarcodeQual
     type: string
     description: |-
@@ -1190,7 +1153,6 @@ argument_groups:
       For instance, for 10X CellRanger or STARsolo BAMs, use --soloInputSAMattrBarcodeQual CY UY .
       If this parameter is '-' (default), the quality 'H' will be assigned to all bases.
     multiple: yes
-    multiple_sep: ;
   - name: --soloStrand
     type: string
     description: |-
@@ -1212,7 +1174,6 @@ argument_groups:
       - GeneFull_Ex50pAS        ... full gene (pre-RNA): count all reads overlapping genes' exons and introns: prioritize >50% overlap with exons. Do not count reads with 100% exonic overlap in the antisense direction.
     example: Gene
     multiple: yes
-    multiple_sep: ;
   - name: --soloMultiMappers
     type: string
     description: |-
@@ -1225,7 +1186,6 @@ argument_groups:
       - EM         ... multi-gene UMIs are distributed using Expectation Maximization algorithm
     example: Unique
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIdedup
     type: string
     description: |-
@@ -1239,7 +1199,6 @@ argument_groups:
       - 1MM_CR                      ... CellRanger2-4 algorithm for 1MM UMI collapsing.
     example: 1MM_All
     multiple: yes
-    multiple_sep: ;
   - name: --soloUMIfiltering
     type: string
     description: |-
@@ -1251,7 +1210,6 @@ argument_groups:
       - MultiGeneUMI_CR    ... basic + remove lower-count UMIs that map to more than one gene, matching CellRanger > 3.0.0 .
       Only works with --soloUMIdedup 1MM_CR
     multiple: yes
-    multiple_sep: ;
   - name: --soloOutFileNames
     type: string
     description: |-
@@ -1264,7 +1222,6 @@ argument_groups:
     - barcodes.tsv
     - matrix.mtx
     multiple: yes
-    multiple_sep: ;
   - name: --soloCellFilter
     type: string
     description: |-
@@ -1284,14 +1241,12 @@ argument_groups:
     - '0.99'
     - '10'
     multiple: yes
-    multiple_sep: ;
   - name: --soloOutFormatFeaturesGeneField3
     type: string
     description: field 3 in the Gene features.tsv file. If "-", then no 3rd field
       is output.
     example: Gene Expression
     multiple: yes
-    multiple_sep: ;
   - name: --soloCellReadStats
     type: string
     description: |-

--- a/src/mapping/star_align/config.vsh.yaml
+++ b/src/mapping/star_align/config.vsh.yaml
@@ -20,7 +20,6 @@ functionality:
           description: The FASTQ files to be analyzed. Corresponds to the --readFilesIn argument in the STAR command.
           example: [ mysample_S1_L001_R1_001.fastq.gz, mysample_S1_L001_R2_001.fastq.gz ]
           multiple: true
-          multiple_sep: ";"
         - type: file
           name: --reference
           alternatives: --genomeDir

--- a/src/mapping/star_align_v273a/config.vsh.yaml
+++ b/src/mapping/star_align_v273a/config.vsh.yaml
@@ -21,7 +21,6 @@ functionality:
           description: The FASTQ files to be analyzed. Corresponds to the --readFilesIn in the STAR command.
           example: [ mysample_S1_L001_R1_001.fastq.gz, mysample_S1_L001_R2_001.fastq.gz ]
           multiple: true
-          multiple_sep: ";"
         - type: file
           name: --reference
           alternatives: --genomeDir

--- a/src/mapping/star_build_reference/config.vsh.yml
+++ b/src/mapping/star_build_reference/config.vsh.yml
@@ -15,7 +15,6 @@ functionality:
           description: The fasta files to be included in the reference. Corresponds to the --genomeFastaFiles argument in the STAR command.
           example: [ chr1.fasta, chr2.fasta ]
           multiple: true
-          multiple_sep: " "
         - name: --transcriptome_gtf
           alternatives: --sjdbGTFfile
           type: file

--- a/src/qc/calculate_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_qc_metrics/config.vsh.yaml
@@ -59,7 +59,7 @@ functionality:
           type: integer
           description: |
             Number of top vars to be used to calculate cumulative proportions.
-            If not specified, proportions are not calculated. `--top_n_vars 20,50` finds
+            If not specified, proportions are not calculated. `--top_n_vars 20;50` finds
             cumulative proportion to the 20th and 50th most expressed vars.
           multiple: true
           required: false

--- a/src/qc/calculate_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_qc_metrics/config.vsh.yaml
@@ -49,7 +49,6 @@ functionality:
             compared to the total sum of the values for all genes.
           type: string
           multiple: True
-          multiple_sep: ','
           example: "ercc,highly_variable,mitochondrial"
         - name: "--var_qc_metrics_fill_na_value"
           type: boolean
@@ -64,7 +63,6 @@ functionality:
             cumulative proportion to the 20th and 50th most expressed vars.
           multiple: true
           required: false
-          multiple_sep: ','
         - name: "--output_obs_num_nonzero_vars"
           description: |
             Name of column in .obs describing, for each observation, the number of stored values

--- a/src/qc/calculate_qc_metrics/test.py
+++ b/src/qc/calculate_qc_metrics/test.py
@@ -61,7 +61,7 @@ def test_add_qc(run_component, input_path):
         "--input", input_path,
         "--output", "foo.h5mu",
         "--modality", "rna",
-        "--top_n_vars", "10,20,90",
+        "--top_n_vars", "10;20;90",
         "--output_compression", "gzip"
         ])
     
@@ -141,7 +141,7 @@ def test_calculcate_qc_var_qc_metrics(run_component, mudata_with_boolean_column,
         "--input", str(mudata_with_boolean_column),
         "--output", str(output_path),
         "--modality", "rna",
-        "--top_n_vars", "10,20,90",
+        "--top_n_vars", "10;20;90",
         "--var_qc_metrics", "custom",
     ]
     if input_data.mod['rna'].var["custom"].isna().any():
@@ -176,7 +176,7 @@ def test_compare_scanpy(run_component,
         "--input", str(mudata_with_boolean_column),
         "--output", str(output_path),
         "--modality", "rna",
-        "--top_n_vars", "10,20,90",
+        "--top_n_vars", "10;20;90",
         "--var_qc_metrics", "custom",
         "--var_qc_metrics_fill_na_value", "False"
         ])


### PR DESCRIPTION
## Changelog

Change separator for arguments with multiple input from `:` to `;`. This is technically a breaking change since arguments like `--input "foo:bar"` would now need to be written as `--input "foo;bar"`. However, this way of writing arguments is not expected to be used in practice.

Note: 
* While it would appear that `,` could also a possible value, this would conflict with the CSV format.

Update: The `foo:bar` or `foo,bar` notation is apparently used a lot in the tests :P

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [x] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!