### PR TITLE
Updated read_percentage function for cellranger multi metrics processing #704

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 * `move_obsm_to_obs`: fix setting output columns when they already exist (PR #690).
 
-* `convert/from_cellranger_multi_to_h5mu`: fix formatting function for percentage values in metrics_summary files (#704).
+* `convert/from_cellranger_multi_to_h5mu`: fix metric values not repesented as percentages being devided by 100. (#704).
 
 # openpipelines 0.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ of a split multimodal files. The modalities in the list must be unique and after
 
 * `move_obsm_to_obs`: fix setting output columns when they already exist (PR #690).
 
+* `convert/from_cellranger_multi_to_h5mu`: fix formatting function for percentage values in metrics_summary files (#704).
+
 # openpipelines 0.12.1
 
 ## BUG FIXES

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -131,7 +131,10 @@ def process_counts(counts_folder: Path):
 def process_metrics_summary(mudata: mudata.MuData, metrics_file: Path):
     def read_percentage(val):
         try:
-            return float(val.strip('%')) / 100
+            if '%' in str(val):
+                return float(val.strip('%')) / 100
+            else:
+                return val
         except (AttributeError, ValueError):
             return val
 

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -131,7 +131,7 @@ def process_counts(counts_folder: Path):
 def process_metrics_summary(mudata: mudata.MuData, metrics_file: Path):
     def read_percentage(val):
         try:
-            if '%' in str(val):
+            if str(val).endswith('%'):
                 return float(val.strip('%')) / 100
             else:
                 return val

--- a/src/convert/from_cellranger_multi_to_h5mu/test.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/test.py
@@ -30,6 +30,17 @@ def test_cellranger_multi_basic(run_component, tmp_path):
     assert list(converted_data.uns.keys()) == ['metrics_cellranger']
     expected_metrics = ['Category', 'Library Type', 'Grouped By', 'Group Name', 'Metric Name', 'Metric Value']
     assert converted_data.uns['metrics_cellranger'].columns.to_list() == expected_metrics
+    # Check that a metric that is stored as percentage (e.g "85.69%") is correctly represented
+    # as a floating point number
+    metrics_df_with_index = converted_data.uns['metrics_cellranger'].set_index(["Metric Name", "Library Type", "Category"]) 
+    percentage = metrics_df_with_index.loc[("Confidently mapped reads in cells", "Gene Expression", "Cells"), "Metric Value"]
+    assert percentage[0] == "0.8569"
+
+    thousand_delimited_number = metrics_df_with_index.loc[("Cells", "Gene Expression", "Cells"), "Metric Value"]
+    thousand_delimited_number == "3,798" 
+
+    smaller_number = metrics_df_with_index.loc[("Median genes per cell", "Gene Expression", "Cells"), "Metric Value"]
+    smaller_number == "6"
     
 def test_cellranger_multi_to_h5mu_crispr(run_component, tmp_path):
     output_path = tmp_path / "output.h5mu"


### PR DESCRIPTION
## Changelog

I updated the `read_percentage()` function in 

## Issue ticket number and link
Closes #704 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contribute)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!
```
====================================================================
+/tmp/viash_test_from_cellranger_multi_to_h5mu8973967691889098180/test_test/test_executable
============================= test session starts ==============================
platform linux -- Python 3.10.13, pytest-8.0.0, pluggy-1.4.0
rootdir: /viash_automount/tmp/viash_test_from_cellranger_multi_to_h5mu8973967691889098180/test_test
plugins: viashpy-0.6.0
collected 2 items

tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py ..                 [100%]

=============================== warnings summary ===============================
tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_basic
tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_basic
tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_basic
tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_to_h5mu_crispr
tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_to_h5mu_crispr
  /usr/local/lib/python3.10/site-packages/anndata/_core/anndata.py:453: PendingDeprecationWarning: The dtype argument will be deprecated in anndata 0.10.0
    warnings.warn(

tmp/viash-run-from_cellranger_multi_to_h5mu-ZnXVcJ.py::test_cellranger_multi_basic
  /usr/local/lib/python3.10/site-packages/anndata/_core/anndata.py:121: ImplicitModificationWarning: Transforming to str index.
    warnings.warn("Transforming to str index.", ImplicitModificationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 2 passed, 6 warnings in 7.08s =========================
====================================================================
SUCCESS! All 1 out of 1 test scripts succeeded!
Cleaning up temporary directory
```