### PR TITLE
Fix double quotes in component descriptions

### DIFF
--- a/src/genetic_demux/demuxlet/config.vsh.yaml
+++ b/src/genetic_demux/demuxlet/config.vsh.yaml
@@ -2,9 +2,10 @@ functionality:
   name: demuxlet
   namespace: genetic_demux
   description: |
-    "Demuxlet is a software tool to deconvolute sample identity and identify multiplets when multiple samples are pooled by barcoded single cell sequencing. |
-    If external genotyping data for each sample is available (e.g. from SNP arrays), demuxlet would be recommended. |
-    Be careful that the parameters on the github is not in line with the newest help version. |
+    Demuxlet is a software tool to deconvolute sample identity and identify multiplets when
+    multiple samples are pooled by barcoded single cell sequencing. If external genotyping data
+    for each sample is available (e.g. from SNP arrays), demuxlet would be recommended. Be careful
+    that the parameters on the github is not in line with the newest help version.
   authors:
     - __merge__: /src/authors/xichen_wu.yaml
       roles: [ author ]

--- a/src/genetic_demux/dsc_pileup/config.vsh.yaml
+++ b/src/genetic_demux/dsc_pileup/config.vsh.yaml
@@ -2,7 +2,10 @@ functionality:
   name: dsc_pileup
   namespace: genetic_demux
   description: |
-    "dsc-pileup is a software tool to pileup reads and corresponding base quality for each overlapping SNPs and each barcode. By using pileup files, it would allow us to run demuxlet/freemuxlet pretty fast multiple times without going over the BAM file again.
+    Dsc-pileup is a software tool to pileup reads and corresponding base quality 
+    for each overlapping SNPs and each barcode. By using pileup files,
+    it would allow us to run demuxlet/freemuxlet pretty fast multiple times
+    without going over the BAM file again.
   authors:
     - __merge__: /src/authors/xichen_wu.yaml
       roles: [ author ]

--- a/src/genetic_demux/freebayes/config.vsh.yaml
+++ b/src/genetic_demux/freebayes/config.vsh.yaml
@@ -1,7 +1,9 @@
 functionality:
   name: freebayes
   namespace: genetic_demux
-  description: "freebayes is a Bayesian genetic variant detector designed to find small polymorphisms, specifically SNPs."
+  description: |
+    Freebayes is a Bayesian genetic variant detector designed to
+    find small polymorphisms, specifically SNPs.
   authors:
     - __merge__: /src/authors/xichen_wu.yaml
       roles: [ author ]

--- a/src/genetic_demux/freemuxlet/config.vsh.yaml
+++ b/src/genetic_demux/freemuxlet/config.vsh.yaml
@@ -2,8 +2,9 @@ functionality:
   name: freemuxlet
   namespace: genetic_demux
   description: |
-    "freemuxlet is a software tool to deconvolute sample identity and identify multiplets when multiple samples are pooled by barcoded single cell sequencing. |
-    If external genotyping data is not available, the genotyping-free version demuxlet, freemuxlet, would be recommended. "
+    Freemuxlet is a software tool to deconvolute sample identity and identify multiplets when
+    multiple samples are pooled by barcoded single cell sequencing. If external genotyping
+    data is not available, the genotyping-free version demuxlet, freemuxlet, would be recommended.
   authors:
     - __merge__: /src/authors/xichen_wu.yaml
       roles: [ author ]


### PR DESCRIPTION
## Changelog

Fix double quotes in several component descriptions.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Documentation
  - [ ] Bug fixes

- ~[ ] Proposed changes are described in the CHANGELOG.md~

- [x] CI tests succeed!