### PR TITLE
grep_annotation_column: fix fractions for sparse input data /w low bitsize dtypes

### DIFF
--- a/src/base/openpipelinetestutils/utils.py
+++ b/src/base/openpipelinetestutils/utils.py
@@ -1,5 +1,6 @@
 from .typing import AnnotationObject
 from typing import Union, Literal
+from functools import reduce
 from operator import attrgetter
 from anndata import AnnData
 from mudata import MuData
@@ -27,17 +28,32 @@ def remove_annotation_column(annotation_object: AnnotationObject,
         axis_setter(annotation_object, axis_getter(annotation_object).drop(column_names,
                                                                         axis="columns",
                                                                         inplace=False))
+
+    def _get_columns_in_all_modalities(annotation_object, axis_string: str):
+        return reduce(
+            lambda a, b: a.intersection(b),
+            [getattr(annotation_object.mod[mod], axis_string).columns
+                for mod in annotation_object.mod],
+        ).to_list()
+
     if isinstance(annotation_object, MuData):
+        if not annotation_object.axis == 0:
+                raise ValueError("This function was designed for mudata objects with .axis=0")
         modality_names = [modality_name] if modality_name else list(annotation_object.mod.keys())
+        global_columns = _get_columns_in_all_modalities(annotation_object, axis_string) \
+                        if axis_string == "var" else []
         extra_cols_to_remove = [f"{mod_name}:{column_name}" for mod_name, column_name
-                                in product(modality_names, column_names)]
+                                in product(modality_names, column_names)
+                                if column_name not in global_columns]
+        extra_cols_to_remove += [column_name for column_name in column_names
+                                 if column_name in global_columns]
         axis_setter(annotation_object, axis_getter(annotation_object).drop(extra_cols_to_remove,
                                                                            axis="columns",
                                                                            inplace=False))
 
         for mod_name in modality_names:
             modality = annotation_object.mod[mod_name]
-            new_modality = remove_annotation_column(modality, column_names, 
+            new_modality = remove_annotation_column(modality, column_names,
                                                     axis=axis, modality_name=None)
-            annotation_object.mod[mod_name] = new_modality 
+            annotation_object.mod[mod_name] = new_modality
     return annotation_object

--- a/src/metadata/grep_annotation_column/script.py
+++ b/src/metadata/grep_annotation_column/script.py
@@ -1,7 +1,7 @@
 import mudata as mu
 from pathlib import Path
-from operator import attrgetter, itemgetter
-from pandas import Series, DataFrame
+from operator import attrgetter
+from pandas import Series
 import scipy as sc
 import re
 import numpy as np
@@ -46,7 +46,7 @@ def describe_array(arr, msg):
     description = sc.stats.describe(arr)._asdict()
     logger.info("%s:\nshape: %s\nmean: %s\nnobs: %s\n"
                 "variance: %s\nmin: %s\nmax: %s\ncontains na: %s\ndtype: %s\ncontains 0: %s",
-                msg, arr.shape, description["mean"], description["nobs"], 
+                msg, arr.shape, description["mean"], description["nobs"],
                 description["variance"], description["minmax"][0],
                 description["minmax"][1], np.isnan(arr).any(), arr.dtype,
                 (arr == 0).any())
@@ -101,7 +101,8 @@ def main(par):
         describe_array(counts_for_matches, "Summary of counts matching grep")
         with np.errstate(all='raise'):
             pct_matching = np.divide(counts_for_matches, totals,
-                                     where=(~np.isclose(totals, 0)))
+                                     out=np.zeros_like(totals, dtype=np.float64),
+                                     where=(~np.isclose(totals, np.zeros_like(totals))))
         logger.info("Testing wether or not fractions data contains NA.")
         assert ~np.isnan(pct_matching).any(), "Fractions should not contain NA."
         logger.info("Fraction statistics: \n%s", Series(pct_matching).describe())

--- a/src/metadata/grep_annotation_column/test.py
+++ b/src/metadata/grep_annotation_column/test.py
@@ -4,11 +4,15 @@
 import sys
 import pytest
 import pandas as pd
+import numpy as np
+import scipy
+import math
 from anndata import AnnData
 from mudata import MuData, read_h5mu
 from subprocess import CalledProcessError
 from openpipelinetestutils.asserters import assert_annotation_objects_equal
 from openpipelinetestutils.utils import remove_annotation_column
+from itertools import permutations, islice
 
 
 ## VIASH START
@@ -35,6 +39,28 @@ def generate_h5mu():
     tmp_mudata = MuData({'mod1': ad1, 'mod2': ad2})
     return tmp_mudata
 
+@pytest.fixture(params=[
+    np.float16, np.float32, np.float64, np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int64
+])
+def very_sparse_mudata(request):
+    rng = np.random.default_rng()
+    shape = (10000, 200)
+    random_counts = scipy.sparse.random(*shape,
+                                        density=0.00001,
+                                        format='csr',
+                                        dtype=request.param,
+                                        random_state=rng,
+                                        data_rvs=lambda length: np.array([1] * length))
+    permutation_length_obs = int(math.log(shape[0])/math.log(26)) + 1
+    obs_index_perms = permutations('abcdefghijklmnopqrstuvwxyz', r=permutation_length_obs)
+    obs_index = pd.Index(["".join(x) for x in islice(obs_index_perms, shape[0])])
+    obs = pd.DataFrame(index=obs_index)
+    permutation_length_var = int(math.log(shape[1])/math.log(26)) + 1
+    var_index_perms = permutations("ABCDEFGHIJKLMNOPQRSTUVWXYZ", r=permutation_length_var)
+    var_index = pd.Index(["".join(x) for x in islice(var_index_perms, shape[1])])
+    var = pd.DataFrame(index=var_index)
+    mod = AnnData(X=random_counts, var=var, obs=obs)
+    return MuData({'mod1': mod})
 
 @pytest.mark.parametrize("compression_format", ["gzip", "lzf"])
 def test_grep_column(run_component, generate_h5mu,
@@ -42,7 +68,7 @@ def test_grep_column(run_component, generate_h5mu,
                      compression_format):
     output_path = random_h5mu_path()
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -99,7 +125,7 @@ def test_grep_column(run_component, generate_h5mu,
                      compression_format):
     output_path = random_h5mu_path()
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -124,11 +150,11 @@ def test_grep_column(run_component, generate_h5mu,
 
 @pytest.mark.parametrize("compression_format", ["gzip", "lzf"])
 def test_grep_column_fraction_column(run_component, generate_h5mu,
-                                     random_h5mu_path, write_mudata_to_file, 
+                                     random_h5mu_path, write_mudata_to_file,
                                      compression_format):
     output_path = random_h5mu_path()
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -148,11 +174,11 @@ def test_grep_column_fraction_column(run_component, generate_h5mu,
     assert "test" in output_data.mod['mod1'].var.columns.to_list()
     assert output_data.mod['mod1'].var['test'].to_list() == [True, False, False]
     assert output_data.mod['mod1'].obs['test_output_fraction'].to_list() == [1/6, 4/15]
-    output_object_without_obs_column = remove_annotation_column(output_data, 
-                                                                ["test_output_fraction"], 
+    output_object_without_obs_column = remove_annotation_column(output_data,
+                                                                ["test_output_fraction"],
                                                                 "obs", "mod1")
-    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column, 
-                                                               ["test"], 
+    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column,
+                                                               ["test"],
                                                                "var", "mod1")
     assert_annotation_objects_equal(input_path,
                                     output_object_without_wo_output,
@@ -164,7 +190,7 @@ def test_fraction_column_nothing_matches(run_component, generate_h5mu,
                                          compression_format):
     output_path = random_h5mu_path()
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -184,11 +210,11 @@ def test_fraction_column_nothing_matches(run_component, generate_h5mu,
     assert "test" in output_data.mod['mod1'].var.columns.to_list()
     assert output_data.mod['mod1'].var['test'].to_list() == [False, False, False]
     assert output_data.mod['mod1'].obs['test_output_fraction'].to_list() == [0.0, 0.0]
-    output_object_without_obs_column = remove_annotation_column(output_data, 
-                                                                ["test_output_fraction"], 
+    output_object_without_obs_column = remove_annotation_column(output_data,
+                                                                ["test_output_fraction"],
                                                                 "obs", "mod1")
-    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column, 
-                                                               ["test"], 
+    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column,
+                                                               ["test"],
                                                                "var", "mod1")
     assert_annotation_objects_equal(input_path,
                                     output_object_without_wo_output,
@@ -197,9 +223,9 @@ def test_fraction_column_nothing_matches(run_component, generate_h5mu,
 def test_fraction_column_with_no_counts(run_component, generate_h5mu,
                                          random_h5mu_path, write_mudata_to_file):
     output_path = random_h5mu_path()
-    generate_h5mu.mod['mod1'].X[0] = 0 
+    generate_h5mu.mod['mod1'].X[0] = 0
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -218,15 +244,46 @@ def test_fraction_column_with_no_counts(run_component, generate_h5mu,
     assert "test" in output_data.mod['mod1'].var.columns.to_list()
     assert output_data.mod['mod1'].var['test'].to_list() == [True, False, False]
     assert output_data.mod['mod1'].obs['test_output_fraction'].to_list() == [0.0, 4/15]
-    output_object_without_obs_column = remove_annotation_column(output_data, 
-                                                                ["test_output_fraction"], 
+    output_object_without_obs_column = remove_annotation_column(output_data,
+                                                                ["test_output_fraction"],
                                                                 "obs", "mod1")
-    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column, 
-                                                               ["test"], 
+    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column,
+                                                               ["test"],
                                                                "var", "mod1")
     assert_annotation_objects_equal(input_path,
                                     output_object_without_wo_output,
-                                    check_data=True) 
+                                    check_data=True)
+
+
+def test_fraction_column_very_sparse(run_component, very_sparse_mudata,
+                                     random_h5mu_path, write_mudata_to_file):
+    output_path = random_h5mu_path()
+    input_path = write_mudata_to_file(very_sparse_mudata)
+
+    # run component
+    run_component([
+        "--input", str(input_path),
+        "--output", str(output_path),
+        "--modality", "mod1",
+        "--matrix", "var",
+        "--regex_pattern", "^a",
+        "--output_match_column", "test",
+        "--output_fraction_column", "test_output_fraction"
+    ])
+    assert output_path.is_file()
+
+    # check output
+    output_data = read_h5mu(output_path)
+    assert "test" in output_data.mod['mod1'].var.columns.to_list()
+    output_object_without_obs_column = remove_annotation_column(output_data,
+                                                                ["test_output_fraction"],
+                                                                "obs", "mod1")
+    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column,
+                                                               ["test"],
+                                                               "var", "mod1")
+    assert_annotation_objects_equal(input_path,
+                                    output_object_without_wo_output,
+                                    check_data=True)
 
 @pytest.mark.parametrize("compression_format", ["gzip", "lzf"])
 def test_fraction_column_input_layer(run_component, generate_h5mu,
@@ -236,7 +293,7 @@ def test_fraction_column_input_layer(run_component, generate_h5mu,
     generate_h5mu.mod["mod1"].layers["test_data"] = generate_h5mu.mod["mod1"].X.copy()
     generate_h5mu.mod["mod1"].X = None
     input_path = write_mudata_to_file(generate_h5mu)
-    
+
     # run component
     run_component([
         "--input", str(input_path),
@@ -257,11 +314,11 @@ def test_fraction_column_input_layer(run_component, generate_h5mu,
     assert "test" in output_data.mod['mod1'].var.columns.to_list()
     assert output_data.mod['mod1'].var['test'].to_list() == [True, False, False]
     output_data.mod['mod1'].obs['test_output_fraction'].to_list() == [1/6, 4/15]
-    output_object_without_obs_column = remove_annotation_column(output_data, 
-                                                                ["test_output_fraction"], 
+    output_object_without_obs_column = remove_annotation_column(output_data,
+                                                                ["test_output_fraction"],
                                                                 "obs", "mod1")
-    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column, 
-                                                               ["test"], 
+    output_object_without_wo_output = remove_annotation_column(output_object_without_obs_column,
+                                                               ["test"],
                                                                "var", "mod1")
     assert_annotation_objects_equal(input_path,
                                     output_object_without_wo_output,


### PR DESCRIPTION
## Changelog

grep_annotation_column: fix fractions for sparse input data /w low bitsize dtypes

## Issue ticket number and link
Closes #718 (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!