### PR TITLE
Remove muon as test dependency for concatenate_h5mu

### DIFF
--- a/src/dataflow/concatenate_h5mu/config.vsh.yaml
+++ b/src/dataflow/concatenate_h5mu/config.vsh.yaml
@@ -74,8 +74,6 @@ platforms:
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, .]
-        packages:
-          - muon
   - type: native
   - type: nextflow
     directives:

--- a/src/dataflow/concatenate_h5mu/test.py
+++ b/src/dataflow/concatenate_h5mu/test.py
@@ -7,7 +7,6 @@ import pytest
 import re
 import sys
 import uuid
-import muon
 
 ## VIASH START
 meta = {
@@ -452,8 +451,8 @@ def test_concat_var_obs_names_order(run_component, mudata_without_genome,
         for mod_name in ["rna", "atac"]:
             data_sample = md.read_h5ad(sample_path, mod=mod_name)
             processed_data = md.read_h5ad("concat.h5mu", mod=mod_name)
-            muon.pp.filter_obs(processed_data, 'sample_id', lambda x: x == sample_name)
-            muon.pp.filter_var(processed_data, data_sample.var_names)
+            processed_data = processed_data[processed_data.obs["sample_id"] == sample_name]
+            processed_data = processed_data[:, data_sample.var_names]
             data_sample_to_test = anndata_to_sparse_dataframe(data_sample)
             processed_data_to_test = anndata_to_sparse_dataframe(processed_data)
             data_sample_to_test = data_sample_to_test.reindex_like(processed_data_to_test)


### PR DESCRIPTION
## Changelog

Remove muon as test dependency for concatenate_h5mu

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

~- [ ] Proposed changes are described in the CHANGELOG.md~

- [x] CI tests succeed!