### PR TITLE
cellranger multi: make the lane optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# openpipelines 1.0.0-rc4
+
+## BUG FIXES
+
+* `mapping/cellranger_multi`: Fix the regex for the fastq input files to allow dropping the lane from the input file names (e.g. `_L001`) (PR #778).
+
 # openpipelines 1.0.0-rc3
 
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# openpipelines 1.0.0-rc4
+# openpipelines x.x.x
 
 ## BUG FIXES
 

--- a/src/mapping/cellranger_multi/script.py
+++ b/src/mapping/cellranger_multi/script.py
@@ -83,7 +83,7 @@ logger = setup_logger()
 fastq_regex = r'^([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.(fastq|fq)(\.gz)?$'
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_L001_R1_001.fastq.gz") is not None
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fq") is not None
-assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz.txt") is None
+# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz.txt") is None
 
 # Invert some parameters. Keep the original ones in the config for compatibility
 inverted_params = {

--- a/src/mapping/cellranger_multi/script.py
+++ b/src/mapping/cellranger_multi/script.py
@@ -80,8 +80,9 @@ def setup_logger():
 # END TEMPORARY WORKAROUND setup_logger
 logger = setup_logger()
 
-fastq_regex = r'([A-Za-z0-9\-_\.]+)_S(\d+)_L(\d+)_[RI](\d+)_(\d+)\.fastq\.gz'
+fastq_regex = r'([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.(fastq|fq)(\.gz)?'
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_L001_R1_001.fastq.gz") is not None
+# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz") is not None
 
 # Invert some parameters. Keep the original ones in the config for compatibility
 inverted_params = {

--- a/src/mapping/cellranger_multi/script.py
+++ b/src/mapping/cellranger_multi/script.py
@@ -80,9 +80,10 @@ def setup_logger():
 # END TEMPORARY WORKAROUND setup_logger
 logger = setup_logger()
 
-fastq_regex = r'([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.(fastq|fq)(\.gz)?'
+fastq_regex = r'^([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.(fastq|fq)(\.gz)?$'
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_L001_R1_001.fastq.gz") is not None
-# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz") is not None
+# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fq") is not None
+assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz.txt") is None
 
 # Invert some parameters. Keep the original ones in the config for compatibility
 inverted_params = {

--- a/src/mapping/cellranger_multi/script.py
+++ b/src/mapping/cellranger_multi/script.py
@@ -80,9 +80,15 @@ def setup_logger():
 # END TEMPORARY WORKAROUND setup_logger
 logger = setup_logger()
 
-fastq_regex = r'^([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.(fastq|fq)(\.gz)?$'
+# Tested with cellranger 7.0:
+# - omitting the lane number is allowed (e.g. `_L001`)
+# - lane number should be omitted across all files if omitted in one
+# - replacing `.fastq.` for `.fq.` is NOT allowed
+# - omitting `.gz` is allowed
+
+fastq_regex = r'^([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.fastq(\.gz)?$'
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_L001_R1_001.fastq.gz") is not None
-# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fq") is not None
+# assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq") is not None
 # assert re.match(fastq_regex, "5k_human_GEX_1_subset_S1_R1_001.fastq.gz.txt") is None
 
 # Invert some parameters. Keep the original ones in the config for compatibility

--- a/src/mapping/cellranger_multi/test.py
+++ b/src/mapping/cellranger_multi/test.py
@@ -278,28 +278,31 @@ def test_cellranger_multi_combined_helper_and_global_input(run_component, random
 
 
 def test_cellranger_multi_with_alternative_names(run_component, random_path):
+    import shutil
+    import gzip
+
     input_dir = random_path()
     input_dir.mkdir()
 
-    # remove L001_ from input1
+    # Note: if one input file does not use any lanes, none of the input files should use lanes
+    # remove lanes
     input1_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_GEX_1_subset_S1_R1_001.fastq.gz"
     input1_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_GEX_1_subset_S1_R2_001.fastq.gz"
+    input2_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_R1_001.fastq.gz"
+    input2_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_R2_001.fastq.gz"
+    input3_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_R1_001.fastq"
+    input3_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_R2_001.fastq"
 
-    # use L004_ instead of L001_
-    input2_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_L004_R1_001.fastq.gz"
-    input2_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_L004_R2_001.fastq.gz"
+    # copy files
+    shutil.copy(input1_R1, input1_R1_link)
+    shutil.copy(input1_R2, input1_R2_link)
+    shutil.copy(input2_R1, input2_R1_link)
+    shutil.copy(input2_R2, input2_R2_link)
 
-    # use fq instead of fastq
-    input3_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_L001_R1_001.fq.gz"
-    input3_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_L001_R2_001.fq.gz"
-
-    # create symlink
-    input1_R1_link.symlink_to(input1_R1)
-    input1_R2_link.symlink_to(input1_R2)
-    input2_R1_link.symlink_to(input2_R1)
-    input2_R2_link.symlink_to(input2_R2)
-    input3_R1_link.symlink_to(input3_R1)
-    input3_R2_link.symlink_to(input3_R2)
+    with gzip.open(input3_R1, 'rb') as f_in:
+        shutil.copyfileobj(f_in, input2_R2_link)
+    with gzip.open(input3_R2, 'rb') as f_in:
+        shutil.copyfileobj(f_in, input3_R2_link)
 
     outputpath = random_path()
     args = [

--- a/src/mapping/cellranger_multi/test.py
+++ b/src/mapping/cellranger_multi/test.py
@@ -276,5 +276,58 @@ def test_cellranger_multi_combined_helper_and_global_input(run_component, random
     # check for vdj data
     assert (outputpath / "per_sample_outs/run/vdj_t/filtered_contig_annotations.csv").is_file()
 
+
+def test_cellranger_multi_with_alternative_names(run_component, random_path):
+    input_dir = random_path()
+    input_dir.mkdir()
+
+    # remove L001_ from input1
+    input1_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_GEX_1_subset_S1_R1_001.fastq.gz"
+    input1_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_GEX_1_subset_S1_R2_001.fastq.gz"
+
+    # use L004_ instead of L001_
+    input2_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_L004_R1_001.fastq.gz"
+    input2_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_AB_subset_S2_L004_R2_001.fastq.gz"
+
+    # use fq instead of fastq
+    input3_R1_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_L001_R1_001.fq.gz"
+    input3_R2_link = input_dir / "5k_human_antiCMV_T_TBNK_connect_VDJ_subset_S1_L001_R2_001.fq.gz"
+
+    # create symlink
+    input1_R1_link.symlink_to(input1_R1)
+    input1_R2_link.symlink_to(input1_R2)
+    input2_R1_link.symlink_to(input2_R1)
+    input2_R2_link.symlink_to(input2_R2)
+    input3_R1_link.symlink_to(input3_R1)
+    input3_R2_link.symlink_to(input3_R2)
+
+    outputpath = random_path()
+    args = [
+            "--output", outputpath,
+            "--input", input1_R1_link,
+            "--input", input1_R2_link,
+            "--abc_input", input2_R1_link,
+            "--abc_input", input2_R2_link,
+            "--vdj_input", input3_R1_link,
+            "--vdj_input", input3_R2_link,
+            "--gex_reference", gex_reference,
+            "--vdj_reference", vdj_reference,
+            "--feature_reference", feature_reference,
+            "--library_id", "5k_human_antiCMV_T_TBNK_connect_GEX_1_subset",
+            "--library_type", "Gene Expression"]
+    run_component(args)
+
+    # check for raw data
+    assert (outputpath / "multi/count/raw_feature_bc_matrix.h5").is_file()
+
+    # check for metrics summary
+    assert (outputpath / "per_sample_outs/run/metrics_summary.csv").is_file()
+
+    # check for filtered gex+ab data
+    assert (outputpath / "per_sample_outs/run/count/sample_filtered_feature_bc_matrix.h5").is_file()
+
+    # check for vdj data
+    assert (outputpath / "per_sample_outs/run/vdj_t/filtered_contig_annotations.csv").is_file()
+
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__]))

--- a/src/mapping/cellranger_multi/test.py
+++ b/src/mapping/cellranger_multi/test.py
@@ -300,9 +300,11 @@ def test_cellranger_multi_with_alternative_names(run_component, random_path):
     shutil.copy(input2_R2, input2_R2_link)
 
     with gzip.open(input3_R1, 'rb') as f_in:
-        shutil.copyfileobj(f_in, input2_R2_link)
+        with open(input3_R1_link, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
     with gzip.open(input3_R2, 'rb') as f_in:
-        shutil.copyfileobj(f_in, input3_R2_link)
+        with open(input3_R2_link, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
     outputpath = random_path()
     args = [


### PR DESCRIPTION
## Changelog

* `mapping/cellranger_multi`: Fix the regex for the fastq input files to allow dropping the lane from the input file names (e.g. `_L001`).

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!