### PR TITLE
Remove unsupported dtype from grep_annotation_column test.

### DIFF
--- a/src/metadata/grep_annotation_column/test.py
+++ b/src/metadata/grep_annotation_column/test.py
@@ -40,9 +40,12 @@ def generate_h5mu():
     return tmp_mudata
 
 @pytest.fixture(params=[
-    np.float16, np.float32, np.float64, np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int64
+    np.float32, np.float64, np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int64
 ])
 def very_sparse_mudata(request):
+    # NOTE: np.float16 is not a supported type in scipy!
+    # See https://github.com/scipy/scipy/issues/20200#issuecomment-1982170609
+    # and https://github.com/scipy/scipy/issues/20200
     rng = np.random.default_rng()
     shape = (10000, 200)
     random_counts = scipy.sparse.random(*shape,


### PR DESCRIPTION
## Changelog

Remove unsupported dtype from grep_annotation_column test.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- ~[ ] Proposed changes are described in the CHANGELOG.md~

- [x] CI tests succeed!