### PR TITLE
add --check_library_compatibility to the cellranger_multi components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 
 * `scgpt/binning` component: Added a scGPT pre-processing binning component (PR #765).
 
+* Added `--check_library_compatibility` to the `mapping/cellranger_multi` component and the `ingestion/cellranger_multi` workflow (PR #xxx).
+  This argument is a inverted replacement of the `--disable_library_compatibility_check` argument in the `mapping/cellranger_multi` component,
+  which will be removed in OpenPipelines 2.0.
+
 ## MINOR CHANGES
 
 * Bump viash to `0.8.6` (PR #815).

--- a/src/mapping/cellranger_multi/cellranger_multi.yaml
+++ b/src/mapping/cellranger_multi/cellranger_multi.yaml
@@ -411,3 +411,18 @@ argument_groups:
         name: --mhc_allele
         description: |
           The MHC allele for TCR Antigen Capture libraries. Must match mhc_allele name specified in the Feature Reference CSV.
+
+  - name: "General arguments"
+    description: |
+      These arguments are applicable to all library types.
+    arguments:
+      - name: "--check_library_compatibility"
+        type: boolean
+        # NOTE: enable this default value when 'disable_library_compatibility_check' is removed from `cellranger_multi` in OpenPipelines 2.0
+        # default: true
+        description: |
+          Optional. This option allows users to disable the check that evaluates 10x Barcode overlap between
+          ibraries when multiple libraries are specified (e.g., Gene Expression + Antibody Capture). Setting
+          this option to false will disable the check across all library combinations. We recommend running
+          this check (default), however if the pipeline errors out, users can bypass the check to generate
+          outputs for troubleshooting.

--- a/src/mapping/cellranger_multi/config.vsh.yaml
+++ b/src/mapping/cellranger_multi/config.vsh.yaml
@@ -29,7 +29,9 @@ functionality:
           type: boolean_true
           description: |
             Disable the check that evaluates 10x Barcode overlap between libraries when multiple libraries are specified 
-            (e.g., Gene Expression + Antibody Capture). Setting this option will disable the check across all library combinations
+            (e.g., Gene Expression + Antibody Capture). Setting this option will disable the check across all library combinations.
+
+            Note: This argument will be deprecated in OpenPipelines 2.0. Use `--check_library_compatibility true/false` instead.
   resources:
     - type: python_script
       path: script.py

--- a/src/mapping/cellranger_multi/script.py
+++ b/src/mapping/cellranger_multi/script.py
@@ -94,12 +94,14 @@ fastq_regex = r'^([A-Za-z0-9\-_\.]+)_S(\d+)_(L(\d+)_)?[RI](\d+)_(\d+)\.fastq(\.g
 # Invert some parameters. Keep the original ones in the config for compatibility
 inverted_params = {
     "gex_no_secondary_analysis": "gex_secondary_analysis",
-    "enable_library_compatibility_check": "disable_library_compatibility_check"
 }
 for inverted_param, param in inverted_params.items():
     par[inverted_param] = not par[param] if par[param] is not None else None
     del par[param]
 
+# NOTE: remove this when `--disable_library_compatibility_check` is removed in OpenPipelines 2.0
+if par["check_library_compatibility"] is None:
+    par["check_library_compatibility"] = not par["disable_library_compatibility_check"]
 
 GEX_CONFIG_KEYS = {
     "gex_reference": "reference",
@@ -110,7 +112,7 @@ GEX_CONFIG_KEYS = {
     "gex_generate_bam": "create-bam",
     "gex_include_introns": "include-introns",
     "min_assignment_confidence": "min-assignment-confidence",
-    "enable_library_compatibility_check": "check-library-compatibility",
+    "check_library_compatibility": "check-library-compatibility",
     "barcode_sample_assignment": "barcode-sample-assignment",
     "cmo_set": "cmo-set",
     "probe_set": "probe-set",

--- a/src/workflows/ingestion/cellranger_multi/main.nf
+++ b/src/workflows/ingestion/cellranger_multi/main.nf
@@ -50,6 +50,7 @@ workflow run_wf {
         "probe_barcode_ids": "probe_barcode_ids",
         "control_id": "control_id",
         "mhc_allele": "mhc_allele",
+        "check_library_compatibility": "check_library_compatibility",
         "output": "output_raw",
       ],
       toState: [


### PR DESCRIPTION
## Changelog


* Added `--check_library_compatibility` to the `mapping/cellranger_multi` component and the `ingestion/cellranger_multi` workflow.
  This argument is a inverted replacement of the `--disable_library_compatibility_check` argument in the `mapping/cellranger_multi` component,
  which will be removed in OpenPipelines 2.0.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!