### PR TITLE
Fix cellranger multi ingestion pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,6 @@
 
 * `mapping/cellranger_multi` component now outputs logs on failure of the `cellranger multi` process (PR #766).
 
-## BUG FIXES
-
-* `ingestion/cellranger_multi`: Make `--output_h5mu` required (PR #820).
-
-* `ingestion/cellranger_multi`: Fix identation in flatMap (PR #820).
-
 # openpipelines 1.0.0-rc6
 
 ## BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@
 
 * `mapping/cellranger_multi` component now outputs logs on failure of the `cellranger multi` process (PR #766).
 
+## BUG FIXES
+
+* `ingestion/cellranger_multi`: Make `--output_h5mu` required (PR #820).
+
+* `ingestion/cellranger_multi`: Fix identation in flatMap (PR #820).
+
 # openpipelines 1.0.0-rc6
 
 ## BUG FIXES

--- a/src/workflows/ingestion/cellranger_multi/config.vsh.yaml
+++ b/src/workflows/ingestion/cellranger_multi/config.vsh.yaml
@@ -25,6 +25,7 @@ functionality:
             which will be replaced with the sample name.
           example: "*.h5mu"
           direction: output
+          required: true
         - name: "--uns_metrics"
           type: string
           description: Name of the .uns slot under which to QC metrics (if any).

--- a/src/workflows/ingestion/cellranger_multi/main.nf
+++ b/src/workflows/ingestion/cellranger_multi/main.nf
@@ -90,8 +90,8 @@ workflow run_wf {
         // So here we overwrite this 'run' id with the name of the input event.
         def new_id = h5mu_list.size() == 1 ? id : corresponding_csv_entry.sample_name
         return [ new_id, ["output_h5mu": h5mu_file, "output_raw": state.output_raw, "_meta": ["join_id": id]]]
-      return result
       }
+      return result
     }
 
   emit:


### PR DESCRIPTION
## Changelog

* `ingestion/cellranger_multi`: Make `--output_h5mu` required.

* `ingestion/cellranger_multi`: Fix identation in flatMap.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!