### PR TITLE
Fix missing dependency in from_cellranger_multi_to_h5mu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@
 
 * `transform/normalize_total` component: pass the `target_sum` argument to `sc.pp.normalize_total()` (PR #823).
 
-* `from_cellranger_multi_to_h5mu`: fix missing `pytest` dependency (PR ).
+* `from_cellranger_multi_to_h5mu`: fix missing `pytest` dependency (PR #897).
 
 ## DOCUMENTATION
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,8 @@
 
 * `transform/normalize_total` component: pass the `target_sum` argument to `sc.pp.normalize_total()` (PR #823).
 
+* `from_cellranger_multi_to_h5mu`: fix missing `pytest` dependency (PR ).
+
 ## DOCUMENTATION
 
 * Update authorship of components (PR #835).

--- a/src/convert/from_cellranger_multi_to_h5mu/config.vsh.yaml
+++ b/src/convert/from_cellranger_multi_to_h5mu/config.vsh.yaml
@@ -71,8 +71,9 @@ engines:
       - type: python
         __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/scanpy.yaml, .]
         packages:
-          - scirpy~=0.12.0
-          - pandas~=2.2.2
+          - scirpy~=0.19.0
+          - pytest # Scirpy has patsy as a dependency and it requires pytest
+          - pandas~=2.2.3
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, .]


### PR DESCRIPTION
## Changelog

... Describe your changes ...

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!