### PR TITLE
temporary workaround dtype casting

### DIFF
--- a/src/dataflow/csr_dtype_cast/config.vsh.yaml
+++ b/src/dataflow/csr_dtype_cast/config.vsh.yaml
@@ -1,0 +1,69 @@
+name: csr_dtype_cast
+namespace: "dataflow"
+description: |
+  Casts the dtypes of AnnData.layer.indptr and AnnData.layer.indices to scipy-compatible dtypes.
+      
+authors:
+  - __merge__: /src/authors/dorien_roosen.yaml
+    roles: [ author ]
+argument_groups:
+  - name: Inputs
+    arguments:
+      - name: "--input"
+        type: file
+        description: Input h5mu file
+        direction: input
+        required: true
+        example: input.h5mu
+      - name: "--modality"
+        type: string
+        default: "rna"
+        required: false
+      - name: "--layer"
+        type: string
+        example: "raw_counts"
+        required: false
+      - name: "--dtype"
+        type: string
+        choices: ["int32", "int64"]
+        default: "int32"
+  
+  - name: Outputs
+    arguments:
+      - name: "--output"
+        type: file
+        description: Output h5mu file.
+        direction: output
+        example: output.h5mu
+      - name: "--output_compression"
+        type: string
+        description: The compression format to be used on the output h5ad object.
+        choices: ["gzip", "lzf"]
+        required: false
+        example: "gzip"
+resources:
+  - type: python_script
+    path: script.py
+
+test_resources:
+  - type: python_script
+    path: test.py
+
+engines:
+  - type: docker
+    image: python:3.11-slim
+    setup:
+      - type: apt
+        packages: 
+          - procps
+      - type: python
+        __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
+        packages:
+          - scipy==1.14.1
+    __merge__: [ /src/base/requirements/python_test_setup.yaml, .]
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [singlecpu, midmem]

--- a/src/dataflow/csr_dtype_cast/script.py
+++ b/src/dataflow/csr_dtype_cast/script.py
@@ -1,0 +1,61 @@
+import mudata as mu
+from scipy.sparse import issparse
+import numpy as np
+
+## VIASH START
+par = {
+    "input": "test.h5mu",
+    "dtype": "int32",
+    "output_compression": None,
+    "modality": "rna",
+    "layer": None,
+    "output": "test_casted.h5mu"
+}
+
+import anndata as ad
+import pandas as pd
+from scipy.sparse import random
+rng = np.random.default_rng(seed=1)
+
+random_counts = random(
+    50000, 100,
+    density=0.8,
+    format='csr',
+    dtype=np.uint32,
+    random_state=rng
+    )
+bad_dtype = random_counts.astype(np.float32)
+bad_dtype.indptr = bad_dtype.indptr.astype(np.uint32)
+bad_dtype.indices = bad_dtype.indices.astype(np.int64)
+del random_counts 
+mod1 = ad.AnnData(
+    X=bad_dtype,
+    obs=pd.DataFrame(index=pd.RangeIndex(50000)),
+    var=pd.DataFrame(index=pd.RangeIndex(100))
+    )
+
+mdata = mu.MuData({"mod1": mod1})
+mdata.write(par["input"])
+par["modality"] = "mod1"
+## VIASH END
+
+# Read in data
+mdata = mu.read_h5mu(par["input"])
+adata = mdata.mod[par["modality"]]
+layer = adata.X if not par['layer'] else adata.layers[par['layer']]
+if not issparse(layer):
+    raise NotImplementedError("Expected layer to be in sparse format.")
+
+# cast dtypes of indptr and indices of csr to scipy-compatible dtypes
+if not layer.indices.dtype == par["dtype"]:
+    layer.indices = layer.indices.astype(par["dtype"])
+if not layer.indptr.dtype == par["dtype"]:
+    layer.indptr = layer.indptr.astype(par["dtype"])
+
+# write data with casted dtype layers back to file
+if not par["layer"]:
+    adata.X = layer
+else:
+    adata.layers[par["layer"]] = layer
+
+mdata.write_h5mu(par["output"], compression=par["output_compression"])

--- a/src/dataflow/csr_dtype_cast/test.py
+++ b/src/dataflow/csr_dtype_cast/test.py
@@ -1,0 +1,64 @@
+import sys
+import pytest
+from pathlib import Path
+import mudata as mu
+import anndata as ad
+import numpy as np
+import pandas as pd
+import uuid
+from scipy.sparse import random, csr_array
+
+
+@pytest.fixture
+def input_mdata():
+    rng = np.random.default_rng(seed=1)
+    random_counts = random(
+        50000, 100,
+        density=0.8,
+        format='csr',
+        dtype=np.uint32,
+        random_state=rng
+        )
+    bad_dtype = random_counts.astype(np.float32)
+    bad_dtype.indptr = bad_dtype.indptr.astype(np.uint32)
+    bad_dtype.indices = bad_dtype.indices.astype(np.int64)
+    del random_counts 
+    mod1 = ad.AnnData(
+        X=bad_dtype,
+        obs=pd.DataFrame(index=pd.RangeIndex(50000)),
+        var=pd.DataFrame(index=pd.RangeIndex(100))
+        )
+
+    return mu.MuData({"mod1": mod1})
+
+
+@pytest.fixture
+def input_mdata_path(tmp_path, input_mdata):
+    output_path = tmp_path / f"{str(uuid.uuid4())}.h5mu"
+    input_mdata.write(output_path)
+    return output_path
+
+
+def test_dtype_casting(
+        run_component,
+        input_mdata_path
+        ):
+
+    args = [
+        "--input", input_mdata_path,
+        "--output", "foo.h5mu",
+        "--modality", "mod1",
+        "--output_compression", "gzip",
+        "--dtype", "int32"
+    ]
+
+    run_component(args)
+    assert Path("foo.h5mu").is_file()
+    mdata = mu.read("foo.h5mu")
+
+    assert mdata.mod["mod1"].X.indices.dtype == np.int32, "Indices dtype not casted correctly"
+    assert mdata.mod["mod1"].X.indptr.dtype == np.int32, "Indptr dtype not casted correctly"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Changelog

Impelemented a *temporary* component to workaround the dtype casting bug (see https://github.com/openpipelines-bio/openpipeline/pull/914 for root cause fix).

- [ ] CI tests succeed!