### PR TITLE
update output parameter of split_h5mu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * `annotate/popv`: fix popv raising `ValueError` when an accelerator (e.g. GPU) is unavailable (PR #915).
 
+* `src/dataflow/split_h5mu`: change output parameter from `--output_files` to `--output_types` to resolve symlink-related publishing issues on Fusion-based infrastructures (PR #922)
+
 ## MINOR CHANGES
 
 * `dataflow/split_h5mu`: Optimize resource usage of the component (PR #913).

--- a/src/dataflow/split_h5mu/config.vsh.yaml
+++ b/src/dataflow/split_h5mu/config.vsh.yaml
@@ -42,7 +42,7 @@ argument_groups:
     choices: ["gzip", "lzf"]
     required: false
     example: "gzip"
-  - name: "--output_files"
+  - name: "--output_types"
     type: file
     required: true
     direction: output

--- a/src/dataflow/split_h5mu/script.py
+++ b/src/dataflow/split_h5mu/script.py
@@ -14,7 +14,7 @@ par = {
   'output': 'reference_download/sample_split',
   'drop_obs_nan': "true",
   'output_compression': None,
-  'output_files': 'reference_download/sample_files.csv',
+  'output_types': 'reference_download/sample_files.csv',
   'ensure_unique_filenames': True
 }
 import anndata as ad
@@ -93,9 +93,9 @@ def main():
         del adata_obs
         gc.collect()
 
-    logger.info(f"Writing output_files CSV file to {par['output_files']}")
+    logger.info(f"Writing output_types CSV file to {par['output_types']}")
     df = pd.DataFrame({"name": obs_features_s, "filename": obs_files})
-    df.to_csv(par["output_files"], index=False)
+    df.to_csv(par["output_types"], index=False)
 
 
 if __name__ == '__main__':

--- a/src/dataflow/split_h5mu/test.py
+++ b/src/dataflow/split_h5mu/test.py
@@ -60,17 +60,17 @@ def input_h5mu_path_non_unique_filenames(write_mudata_to_file, input_h5mu_non_un
 
 def test_sample_split(run_component, random_path, input_h5mu, input_h5mu_path):
     output_dir = random_path()
-    output_files = random_path(extension="csv")
+    output_types = random_path(extension="csv")
     args = [
         "--input", input_h5mu_path,
         "--output", str(output_dir),
         "--modality", "mod1",
         "--obs_feature", "Obs",
-        "--output_files", str(output_files),
+        "--output_types", str(output_types),
     ]
 
     run_component(args)
-    assert output_files.is_file()
+    assert output_types.is_file()
     assert output_dir.is_dir()
 
     # check output dir and file names
@@ -119,21 +119,21 @@ def test_sample_split(run_component, random_path, input_h5mu, input_h5mu_path):
         B,{s2_file.name}
         """
     )
-    with open(output_files, 'r') as open_csv_file:
+    with open(output_types, 'r') as open_csv_file:
         result = open_csv_file.read()
         assert result == expected_csv_output
 
 
 def test_sample_split_dropna(run_component, random_path, input_h5mu, input_h5mu_path):
     output_dir = random_path()
-    output_files = random_path(extension="csv")
+    output_types = random_path(extension="csv")
     args = [
         "--input", input_h5mu_path,
         "--output", str(output_dir),
         "--modality", "mod1",
         "--obs_feature", "Obs",
         "--drop_obs_nan", "true",
-        "--output_files", str(output_files),
+        "--output_types", str(output_types),
     ]
 
     run_component(args)
@@ -157,7 +157,7 @@ def test_sample_split_dropna(run_component, random_path, input_h5mu, input_h5mu_
 
 def test_sanitizing(run_component, random_path, input_h5mu_path_non_unique_filenames):
     output_dir = random_path()
-    output_files = random_path(extension="csv")
+    output_types = random_path(extension="csv")
 
     args = [
         "--input", input_h5mu_path_non_unique_filenames,
@@ -165,7 +165,7 @@ def test_sanitizing(run_component, random_path, input_h5mu_path_non_unique_filen
         "--modality", "mod3",
         "--obs_feature", "Obs",
         "--drop_obs_nan", "true",
-        "--output_files", str(output_files)
+        "--output_types", str(output_types)
     ]
 
     with pytest.raises(subprocess.CalledProcessError) as err:
@@ -180,7 +180,7 @@ def test_sanitizing(run_component, random_path, input_h5mu_path_non_unique_filen
             "--modality", "mod3",
             "--obs_feature", "Obs",
             "--drop_obs_nan", "true",
-            "--output_files", str(output_files),
+            "--output_types", str(output_types),
             "--ensure_unique_filenames", "true"
         ]
 


### PR DESCRIPTION
## Changelog

parameter name for output csv is now `output_types` instead of `output_files`, to resolve publishing issues with fusion

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!