### PR TITLE
make sure var_input column is bool dtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 # BUG FIXES
 
-* `utils/subset_vars`: Convert .var column used for subsetting of dtype "boolean" to dtypa "bool" when it doesn't contain NaN values (PR #959).
+* `utils/subset_vars`: Convert .var column used for subsetting of dtype "boolean" to dtype "bool" when it doesn't contain NaN values (PR #959).
 
 # openpipelines 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 * `feature_annotation/highly_variable_features_scanpy`: Enable calculation of HVG on a subset of genes (PR #957).
 
+# BUG FIXES
+
+* `utils/subset_vars`: Convert .var column used for subsetting of dtype "boolean" to dtypa "bool" when it doesn't contain NaN values (PR #959).
+
 # openpipelines 2.0.0
 
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 * Various  components (`scgpt` and `annotate`): Add resource labels (PR #947, PR #950).
 
-* `feature_annotation/highly_variable_features_scanpy`: Enable calculation of HVG on a subset of genes (PR #957).
+* `feature_annotation/highly_variable_features_scanpy`: Enable calculation of HVG on a subset of genes (PR #957, PR #959).
 
 # BUG FIXES
 

--- a/src/feature_annotation/highly_variable_features_scanpy/script.py
+++ b/src/feature_annotation/highly_variable_features_scanpy/script.py
@@ -140,7 +140,7 @@ if par["flavor"] == "seurat_v3" and not par["n_top_features"]:
 try:
     out = sc.pp.highly_variable_genes(**hvg_args)
     if par["var_input"] is not None:
-        out.index = data[:, data.var[par["var_input"]]].var.index
+        out.index = input_anndata.var.index
         out = out.reindex(index=data.var.index, method=None)
         out.highly_variable = out.highly_variable.fillna(False)
         assert (

--- a/src/feature_annotation/highly_variable_features_scanpy/test.py
+++ b/src/feature_annotation/highly_variable_features_scanpy/test.py
@@ -74,6 +74,7 @@ def common_vars_data_path(tmp_path, lognormed_test_data):
     rna_in = lognormed_test_data.mod["rna"]
     rna_in.var["common_vars"] = False
     rna_in.var["common_vars"].iloc[:10000] = True
+    rna_in.var["common_vars"] = rna_in.var["common_vars"].astype("boolean")
     lognormed_test_data.write_h5mu(temp_h5mu)
     return temp_h5mu
 

--- a/src/utils/subset_vars.py
+++ b/src/utils/subset_vars.py
@@ -18,4 +18,14 @@ def subset_vars(adata, subset_col):
             f"Requested to use .var column '{subset_col}' as a selection of genes, but the column is not available."
         )
 
+    if adata.var[subset_col].dtype == "boolean":
+        assert (
+            adata.var[subset_col].isna().sum() == 0
+        ), f"The .var column `{subset_col}` contains NaN values. Can not subset data."
+        adata.var[subset_col] = adata.var[subset_col].astype("bool")
+
+    assert (
+        adata.var[subset_col].dtype == "bool"
+    ), f"Expected dtype of .var column '{subset_col}' to be `bool`, but found {adata.var[subset_col].dtype}. Can not subset data."
+
     return adata[:, adata.var[subset_col]].copy()


### PR DESCRIPTION
## Changelog

After concatenating datasets, .var columns containing bool values are converted to "boolean" dtype (https://github.com/openpipelines-bio/openpipeline/blob/main/src/dataflow/concatenate_h5mu/script.py#L151), which doesn't allow subsetting of the data. 
This PR converts "boolean" var columns used to subset the vars to "bool" dtype, where possible, or raises if not.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!