### PR TITLE
pin torch version for scanvi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 * `utils/subset_vars`: Convert .var column used for subsetting of dtype "boolean" to dtype "bool" when it doesn't contain NaN values (PR #959).
 
+* `annotate/scanvi`: Change base image for running scanvi to pin pytorch version and enable gpu processing (PR #966).
+
 # openpipelines 2.0.0
 
 ## BREAKING CHANGES

--- a/src/annotate/scanvi/config.vsh.yaml
+++ b/src/annotate/scanvi/config.vsh.yaml
@@ -215,6 +215,7 @@ engines:
         - scvi-tools~=1.0.3      
         - jaxlib<0.4.23
         - jax<0.4.23
+        - torch<2.6.0
   __merge__: [ /src/base/requirements/python_test_setup.yaml, .]
 runners:
   - type: executable

--- a/src/annotate/scanvi/config.vsh.yaml
+++ b/src/annotate/scanvi/config.vsh.yaml
@@ -207,18 +207,14 @@ test_resources:
 
 engines:
 - type: docker
-  image: python:3.12-slim
+  image: nvcr.io/nvidia/pytorch:23.09-py3
   setup:
-    - type: apt
+    - type: python
+      __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
       packages:
-        - procps
-    - type: python
-      __merge__: [ /src/base/requirements/scanpy.yaml, .]
-    - type: python
-      packages:
-        - scvi-tools==1.1.5
-    - type: python
-      __merge__: [ /src/base/requirements/anndata_mudata.yaml, .]
+        - scvi-tools~=1.0.3      
+        - jaxlib<0.4.23
+        - jax<0.4.23
   __merge__: [ /src/base/requirements/python_test_setup.yaml, .]
 runners:
   - type: executable


### PR DESCRIPTION
## Changelog

Change base image for running scanvi to nvcr.io/nvidia/pytorch:23.09-py3, to:
- pin torch to compatible version with scvi-tools
- enable gpu processing

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!