### PR TITLE
handle dtypes for Float during merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 
 * `workflows/annotation/scgpt_annotation` and `workflows/integrate/scgpt_leiden`: Parameterization of HVG flavor with default method `cell_ranger` instead of `seurat_v3` (PR #979).
 
+* `dataflow/merge`: Convert nullable Float dtypes to numpy floats (PR #959).
+
 # openpipelines 2.0.0
 
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,7 @@
 
 * `workflows/annotation/scgpt_annotation` and `workflows/integrate/scgpt_leiden`: Parameterization of HVG flavor with default method `cell_ranger` instead of `seurat_v3` (PR #979).
 
-* `dataflow/merge`: Casting of nullable dtypes that are not supported by MuData/AnnData to their native numpy dtypes (PR #959).
-
+* `dataflow/merge`: Resolved an issue where merging two MuData objects with overlapping `var` or `obs` columns sometimes resulted in an unsupported nullable dtype (e.g. merging `pd.IntegerDtype` and `pd.FloatDtype`). These columns are now correctly cast to their native numpy dtypes before writing(PR #990).
 # openpipelines 2.0.0
 
 ## BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 * `workflows/annotation/scgpt_annotation` and `workflows/integrate/scgpt_leiden`: Parameterization of HVG flavor with default method `cell_ranger` instead of `seurat_v3` (PR #979).
 
-* `dataflow/merge`: Convert nullable Float dtypes to numpy floats (PR #959).
+* `dataflow/merge`: Casting of nullable dtypes to their native numpy dtypes (PR #959).
 
 # openpipelines 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 * `workflows/annotation/scgpt_annotation` and `workflows/integrate/scgpt_leiden`: Parameterization of HVG flavor with default method `cell_ranger` instead of `seurat_v3` (PR #979).
 
-* `dataflow/merge`: Casting of nullable dtypes to their native numpy dtypes (PR #959).
+* `dataflow/merge`: Casting of nullable dtypes that are not supported by MuData/AnnData to their native numpy dtypes (PR #959).
 
 # openpipelines 2.0.0
 

--- a/src/dataflow/merge/script.py
+++ b/src/dataflow/merge/script.py
@@ -8,8 +8,8 @@ import numpy as np
 ### VIASH START
 par = {
     "input": [
-        "merged.align_query_reference.output_query_prot.h5mu",
-        "merged.knn.output.h5mu",
+        "./resources_test/merge/pbmc_1k_protein_v3_filtered_feature_bc_matrix_rna.h5mu",
+        "./resources_test/merge/pbmc_1k_protein_v3_filtered_feature_bc_matrix_prot.h5mu",
     ],
     "output": "foo.h5mu",
     "output_compression": None,

--- a/src/dataflow/merge/script.py
+++ b/src/dataflow/merge/script.py
@@ -61,13 +61,9 @@ def main():
             df[obj_col] = df[obj_col].astype(str).astype("category")
             
         # Nullable float columns are not supported by anndata/mudata
-        float64_cols = df.select_dtypes(include=pd.Float64Dtype())
-        for float64_col in float64_cols:
-            df[float64_col] = df[float64_col].astype(np.float64)
-        
-        float32_cols = df.select_dtypes(include=pd.Float32Dtype())
-        for float32_col in float32_cols:
-            df[float32_col] = df[float32_col].astype(np.float32)
+        float_cols = df.select_dtypes(include=[pd.Float64Dtype(), pd.Float32Dtype()]).columns.values
+        for float_col in float_cols:
+            df[float_col] = df[float_col].astype(df[float_col].dtype.numpy_dtype)
             
         setattr(merged, df_attr, df)
 

--- a/src/dataflow/merge/script.py
+++ b/src/dataflow/merge/script.py
@@ -12,11 +12,9 @@ par = {
         "merged.knn.output.h5mu",
     ],
     "output": "foo.h5mu",
-    "output_compression": None
+    "output_compression": None,
 }
-meta = {
-    "resources_dir": "src/utils"
-}
+meta = {"resources_dir": "src/utils"}
 ### VIASH END
 
 sys.path.append(meta["resources_dir"])
@@ -59,12 +57,15 @@ def main():
         object_cols = df.select_dtypes(include="object").columns.values
         for obj_col in object_cols:
             df[obj_col] = df[obj_col].astype(str).astype("category")
-            
+
         # Nullable float columns are not supported by anndata/mudata
-        float_cols = df.select_dtypes(include=[pd.Float64Dtype(), pd.Float32Dtype()]).columns.values
+        float_cols = df.select_dtypes(
+            include=[pd.Float64Dtype(), pd.Float32Dtype()]
+        ).columns.values
         for float_col in float_cols:
-            df[float_col] = df[float_col].astype(df[float_col].dtype.numpy_dtype)
-            
+            numpy_dtype = df[float_col].dtype.type
+            df[float_col] = df[float_col].astype(numpy_dtype)
+
         setattr(merged, df_attr, df)
 
     merged.write_h5mu(par["output"], compression=par["output_compression"])

--- a/src/dataflow/merge/script.py
+++ b/src/dataflow/merge/script.py
@@ -52,7 +52,7 @@ def main():
             convert_integer=True,
             convert_string=False,
             convert_boolean=True,
-            convert_floating=True,
+            convert_floating=False,
         )
 
         # Convert leftover 'object' columns to string

--- a/src/dataflow/merge/script.py
+++ b/src/dataflow/merge/script.py
@@ -53,18 +53,26 @@ def main():
             convert_floating=False,
         )
 
+        # pd.convert_dtypes does not convert already existing nullable dtypes
+        # to their native numpy dtypes.
+        # At this point, integer and boolean columns use a nullable dtype; and string columns
+        # might use 'object' or pd.StringDtype. This is OK.
+        # However, for example floating number columns might still use a nullable dtype
+        # from before the call to convert_dtypes. So we need to explicitly cast.
+        col_dtypes = df.select_dtypes(
+            exclude=["integer", "string", "object", "boolean"]
+        ).dtypes.to_dict()
+        numpy_dtypes = {
+            col_name: np.dtype(col_dtype.kind)
+            for col_name, col_dtype in col_dtypes.items()
+            if pd.api.types.is_extension_array_dtype(col_dtype)
+        }
+        df = df.astype(numpy_dtypes)
+
         # Convert leftover 'object' columns to string
         object_cols = df.select_dtypes(include="object").columns.values
         for obj_col in object_cols:
             df[obj_col] = df[obj_col].astype(str).astype("category")
-
-        # Nullable float columns are not supported by anndata/mudata
-        float_cols = df.select_dtypes(
-            include=[pd.Float64Dtype(), pd.Float32Dtype()]
-        ).columns.values
-        for float_col in float_cols:
-            numpy_dtype = df[float_col].dtype.type
-            df[float_col] = df[float_col].astype(numpy_dtype)
 
         setattr(merged, df_attr, df)
 

--- a/src/dataflow/merge/test.py
+++ b/src/dataflow/merge/test.py
@@ -1,84 +1,251 @@
-from __future__ import annotations
 import sys
-import mudata as md
+import pytest
+import subprocess
+from mudata import MuData, read_h5mu
 import pandas as pd
 import numpy as np
+import re
+from openpipeline_testutils.asserters import assert_annotation_objects_equal
 
-
-### VIASH START
-par = {
-    "input": [
-        "merged.align_query_reference.output_query_prot.h5mu",
-        "merged.knn.output.h5mu",
-    ],
-    "output": "foo.h5mu",
-    "output_compression": None,
+## VIASH START
+meta = {
+    "executable": "./target/executable/dataflow/merge/merge",
+    "resources_dir": "./resources_test/merge_test_data/",
+    "config": "./src/dataflow/merge/config.vsh.yml",
 }
-meta = {"resources_dir": "src/utils"}
-### VIASH END
-
-sys.path.append(meta["resources_dir"])
-from setup_logger import setup_logger
-
-logger = setup_logger()
+## VIASH END
 
 
-def main():
-    logger.info("Reading input files %s", ",".join(par["input"]))
-    input_samples = [md.read_h5mu(path) for path in par["input"]]
+@pytest.fixture
+def mudata_non_overlapping_observations(request, random_h5mu_path):
+    mudata_to_change_path = request.getfixturevalue(request.param)
+    # mudata_to_change_path = small_mudata_mod1_path
+    temp_h5mu = random_h5mu_path()
+    mudata_to_change = read_h5mu(mudata_to_change_path)
+    # Remove 1 observation
+    removed_observation_name = mudata_to_change.obs.index[-1]
+    mudata_to_change = mudata_to_change[: mudata_to_change.n_obs - 1]
+    mudata_to_change.write(temp_h5mu, compression="gzip")
+    return temp_h5mu, removed_observation_name
 
-    logger.info("Merging into single object.")
-    sample_modalities = {}
-    for input_sample in input_samples:
-        for mod_name, mod_data in input_sample.mod.items():
-            if mod_name in sample_modalities:
-                raise ValueError(
-                    f"Modality '{mod_name}' was found in more than 1 sample."
-                )
-            sample_modalities[mod_name] = mod_data
 
-    merged = md.MuData(sample_modalities)
-    merged.update()
-    for df_attr in ("var", "obs"):
-        df = getattr(merged, df_attr)
-        df = df.replace({pd.NA: np.nan}, inplace=False)
+@pytest.fixture
+def extra_var_column_value():
+    return "bar"
 
-        # MuData supports nullable booleans and ints
-        # ie. `IntegerArray` and `BooleanArray`
-        df = df.convert_dtypes(
+
+@pytest.fixture
+def extra_var_column_name():
+    return "test"
+
+
+@pytest.fixture
+def mudata_with_extra_var_column(
+    random_h5mu_path, request, extra_var_column_value, extra_var_column_name
+):
+    [sample1_path, sample2_path] = request.getfixturevalue(request.param)
+    result = []
+    for sample_path, column_value in (
+        (sample1_path, extra_var_column_value),
+        (sample2_path, np.nan),
+    ):
+        sample = read_h5mu(sample_path)
+        mod_names = list(sample.mod.keys())
+        assert len(mod_names) == 1
+        mod_name = mod_names[0]
+        sample.mod[mod_name].var[extra_var_column_name] = column_value
+        sample.var = sample.var.convert_dtypes(
             infer_objects=True,
             convert_integer=True,
             convert_string=False,
             convert_boolean=True,
             convert_floating=False,
         )
+        new_path = random_h5mu_path()
+        sample.write(new_path)
+        result.append(new_path)
+    return result
 
-        # pd.convert_dtypes does not convert already existing nullable dtypes
-        # to their native numpy dtypes.
-        # At this point, integer and boolean columns use a nullable dtype; and string columns
-        # might use 'object' or pd.StringDtype. This is OK.
-        # However, for example floating number columns might still use a nullable dtype
-        # from before the call to convert_dtypes. So we need to explicitly cast.
-        col_dtypes = df.select_dtypes(
-            exclude=["integer", "string", "object", "boolean"]
-        ).dtypes.to_dict()
-        numpy_dtypes = {
-            col_name: np.dtype(col_dtype.kind)
-            for col_name, col_dtype in col_dtypes.items()
-            if pd.api.types.is_extension_array_dtype(col_dtype)
+
+def test_merge(
+    run_component, random_h5mu_path, small_mudata_mod1_path, small_mudata_mod2_path
+):
+    """
+    Test a simple merge with fully overlapping observations
+    """
+    output_path = random_h5mu_path()
+    # input_sample1_path, input_sample2_path = split_small_mudata_path
+    args = [
+        "--input",
+        small_mudata_mod1_path,
+        "--input",
+        small_mudata_mod2_path,
+        "--output",
+        output_path,
+        "--output_compression",
+        "gzip",
+    ]
+    run_component(args)
+
+    assert output_path.is_file()
+    concatenated_data = read_h5mu(output_path)
+    data_sample1 = read_h5mu(small_mudata_mod1_path)
+    data_sample2 = read_h5mu(small_mudata_mod2_path)
+
+    expected_concatenated_data = MuData(
+        {"mod1": data_sample1.mod["mod1"], "mod2": data_sample2.mod["mod2"]}
+    )
+    assert_annotation_objects_equal(concatenated_data, expected_concatenated_data)
+
+
+@pytest.mark.parametrize(
+    "mudata_non_overlapping_observations",
+    ["small_mudata_mod1_path"],
+    indirect=["mudata_non_overlapping_observations"],
+)
+def test_merge_non_overlapping_observations(
+    run_component,
+    mudata_non_overlapping_observations,
+    random_h5mu_path,
+    small_mudata_mod2_path,
+):
+    """
+    Merge with differing observations in the samples
+    """
+    edited_h5mu_path, removed_observation_name = mudata_non_overlapping_observations
+    output_path = random_h5mu_path()
+    # Remove 1 observation
+    run_component(
+        [
+            "--input",
+            edited_h5mu_path,
+            "--input",
+            small_mudata_mod2_path,
+            "--output",
+            output_path,
+        ]
+    )
+
+    assert output_path.is_file()
+    concatenated_data = read_h5mu(output_path, backed=False)
+    data_sample1 = read_h5mu(edited_h5mu_path, backed=False)
+    data_sample2 = read_h5mu(small_mudata_mod2_path, backed=False)
+
+    expected_concatenated_data = MuData(
+        {"mod1": data_sample1.mod["mod1"], "mod2": data_sample2.mod["mod2"]}
+    )
+
+    assert set(concatenated_data.obs_names) == (
+        set(data_sample1.obs_names) | set(data_sample2.obs_names)
+    )
+    assert concatenated_data[removed_observation_name:]["mod1"].n_obs == 0
+    assert concatenated_data[removed_observation_name:]["mod2"].n_obs == 1
+
+    np.testing.assert_equal(
+        concatenated_data.copy()[removed_observation_name:]["mod2"].X.data,
+        data_sample2.copy()[removed_observation_name:]["mod2"].X.data,
+    )
+
+    assert_annotation_objects_equal(concatenated_data, expected_concatenated_data)
+
+
+@pytest.mark.parametrize(
+    "extra_var_column_name,extra_var_column_value,expected",
+    [
+        ("test", "bar", "bar"),
+        ("test", True, True),
+        ("test", 0.1, 0.1),
+        ("test", np.nan, pd.NA),
+    ],
+)
+@pytest.mark.parametrize(
+    "mudata_with_extra_var_column",
+    ["split_small_mudata_path"],
+    indirect=["mudata_with_extra_var_column"],
+)
+def test_boolean_and_na_types(
+    run_component,
+    mudata_with_extra_var_column,
+    extra_var_column_name,
+    expected,
+    random_h5mu_path,
+):
+    """
+    Test if merging booleans of NAs results in the .var .obs column being writeable
+    """
+    input_sample1_path, input_sample2_path = mudata_with_extra_var_column
+    output_path = random_h5mu_path()
+
+    run_component(
+        [
+            "--input",
+            input_sample1_path,
+            "--input",
+            input_sample2_path,
+            "--output",
+            output_path,
+        ]
+    )
+    assert output_path.is_file()
+    merged_data = read_h5mu(output_path, backed=False)
+    first_sample_mod = list(read_h5mu(input_sample1_path).mod)[0]
+    second_sample_mod = list(read_h5mu(input_sample2_path).mod)[0]
+
+    expected_merged_data = MuData(
+        {
+            "mod1": read_h5mu(input_sample1_path).mod["mod1"],
+            "mod2": read_h5mu(input_sample2_path).mod["mod2"],
         }
-        df = df.astype(numpy_dtypes)
+    )
 
-        # Convert leftover 'object' columns to string
-        object_cols = df.select_dtypes(include="object").columns.values
-        for obj_col in object_cols:
-            df[obj_col] = df[obj_col].astype(str).astype("category")
+    if not pd.isna(expected):
+        assert merged_data.var.loc["var1"][extra_var_column_name] == expected
+        assert (
+            merged_data.mod[first_sample_mod].var.loc["var1"][extra_var_column_name]
+            == expected
+        )
+    else:
+        assert pd.isna(merged_data.var.loc["var1"][extra_var_column_name])
+        assert pd.isna(
+            merged_data.mod[first_sample_mod].var.loc["var1"][extra_var_column_name]
+        )
+    assert pd.isna(merged_data.var.loc["var4"][extra_var_column_name])
+    assert pd.isna(
+        merged_data.mod[second_sample_mod].var.loc["var4"][extra_var_column_name]
+    )
 
-        setattr(merged, df_attr, df)
+    assert_annotation_objects_equal(merged_data, expected_merged_data)
 
-    merged.write_h5mu(par["output"], compression=par["output_compression"])
-    logger.info("Finished")
+
+def test_same_modalities_raises(
+    run_component, random_h5mu_path, split_small_mudata_path
+):
+    """
+    Raise when trying to merge modalities with the same name.
+    """
+    input_sample1_path, input_sample2_path = split_small_mudata_path
+    input_sample2_edited_path = random_h5mu_path()
+    output_path = random_h5mu_path()
+    data_sample2 = read_h5mu(input_sample2_path)
+    data_sample2 = MuData({"mod1": data_sample2.mod["mod2"]})
+    data_sample2.write(input_sample2_edited_path, compression="gzip")
+
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input",
+                input_sample1_path,
+                "--input",
+                input_sample2_edited_path,
+                "--output",
+                output_path,
+            ]
+        )
+    assert re.search(
+        r"ValueError: Modality 'mod1' was found in more than 1 sample\.",
+        err.value.stdout.decode("utf-8"),
+    )
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(pytest.main([__file__]))

--- a/src/dataflow/merge/test.py
+++ b/src/dataflow/merge/test.py
@@ -1,251 +1,84 @@
+from __future__ import annotations
 import sys
-import pytest
-import subprocess
-from mudata import MuData, read_h5mu
+import mudata as md
 import pandas as pd
 import numpy as np
-import re
-from openpipeline_testutils.asserters import assert_annotation_objects_equal
 
-## VIASH START
-meta = {
-    "executable": "./target/executable/dataflow/merge/merge",
-    "resources_dir": "./resources_test/merge_test_data/",
-    "config": "./src/dataflow/merge/config.vsh.yml",
+
+### VIASH START
+par = {
+    "input": [
+        "merged.align_query_reference.output_query_prot.h5mu",
+        "merged.knn.output.h5mu",
+    ],
+    "output": "foo.h5mu",
+    "output_compression": None,
 }
-## VIASH END
+meta = {"resources_dir": "src/utils"}
+### VIASH END
+
+sys.path.append(meta["resources_dir"])
+from setup_logger import setup_logger
+
+logger = setup_logger()
 
 
-@pytest.fixture
-def mudata_non_overlapping_observations(request, random_h5mu_path):
-    mudata_to_change_path = request.getfixturevalue(request.param)
-    # mudata_to_change_path = small_mudata_mod1_path
-    temp_h5mu = random_h5mu_path()
-    mudata_to_change = read_h5mu(mudata_to_change_path)
-    # Remove 1 observation
-    removed_observation_name = mudata_to_change.obs.index[-1]
-    mudata_to_change = mudata_to_change[: mudata_to_change.n_obs - 1]
-    mudata_to_change.write(temp_h5mu, compression="gzip")
-    return temp_h5mu, removed_observation_name
+def main():
+    logger.info("Reading input files %s", ",".join(par["input"]))
+    input_samples = [md.read_h5mu(path) for path in par["input"]]
 
+    logger.info("Merging into single object.")
+    sample_modalities = {}
+    for input_sample in input_samples:
+        for mod_name, mod_data in input_sample.mod.items():
+            if mod_name in sample_modalities:
+                raise ValueError(
+                    f"Modality '{mod_name}' was found in more than 1 sample."
+                )
+            sample_modalities[mod_name] = mod_data
 
-@pytest.fixture
-def extra_var_column_value():
-    return "bar"
+    merged = md.MuData(sample_modalities)
+    merged.update()
+    for df_attr in ("var", "obs"):
+        df = getattr(merged, df_attr)
+        df = df.replace({pd.NA: np.nan}, inplace=False)
 
-
-@pytest.fixture
-def extra_var_column_name():
-    return "test"
-
-
-@pytest.fixture
-def mudata_with_extra_var_column(
-    random_h5mu_path, request, extra_var_column_value, extra_var_column_name
-):
-    [sample1_path, sample2_path] = request.getfixturevalue(request.param)
-    result = []
-    for sample_path, column_value in (
-        (sample1_path, extra_var_column_value),
-        (sample2_path, np.nan),
-    ):
-        sample = read_h5mu(sample_path)
-        mod_names = list(sample.mod.keys())
-        assert len(mod_names) == 1
-        mod_name = mod_names[0]
-        sample.mod[mod_name].var[extra_var_column_name] = column_value
-        sample.var = sample.var.convert_dtypes(
+        # MuData supports nullable booleans and ints
+        # ie. `IntegerArray` and `BooleanArray`
+        df = df.convert_dtypes(
             infer_objects=True,
             convert_integer=True,
             convert_string=False,
             convert_boolean=True,
             convert_floating=False,
         )
-        new_path = random_h5mu_path()
-        sample.write(new_path)
-        result.append(new_path)
-    return result
 
-
-def test_merge(
-    run_component, random_h5mu_path, small_mudata_mod1_path, small_mudata_mod2_path
-):
-    """
-    Test a simple merge with fully overlapping observations
-    """
-    output_path = random_h5mu_path()
-    # input_sample1_path, input_sample2_path = split_small_mudata_path
-    args = [
-        "--input",
-        small_mudata_mod1_path,
-        "--input",
-        small_mudata_mod2_path,
-        "--output",
-        output_path,
-        "--output_compression",
-        "gzip",
-    ]
-    run_component(args)
-
-    assert output_path.is_file()
-    concatenated_data = read_h5mu(output_path)
-    data_sample1 = read_h5mu(small_mudata_mod1_path)
-    data_sample2 = read_h5mu(small_mudata_mod2_path)
-
-    expected_concatenated_data = MuData(
-        {"mod1": data_sample1.mod["mod1"], "mod2": data_sample2.mod["mod2"]}
-    )
-    assert_annotation_objects_equal(concatenated_data, expected_concatenated_data)
-
-
-@pytest.mark.parametrize(
-    "mudata_non_overlapping_observations",
-    ["small_mudata_mod1_path"],
-    indirect=["mudata_non_overlapping_observations"],
-)
-def test_merge_non_overlapping_observations(
-    run_component,
-    mudata_non_overlapping_observations,
-    random_h5mu_path,
-    small_mudata_mod2_path,
-):
-    """
-    Merge with differing observations in the samples
-    """
-    edited_h5mu_path, removed_observation_name = mudata_non_overlapping_observations
-    output_path = random_h5mu_path()
-    # Remove 1 observation
-    run_component(
-        [
-            "--input",
-            edited_h5mu_path,
-            "--input",
-            small_mudata_mod2_path,
-            "--output",
-            output_path,
-        ]
-    )
-
-    assert output_path.is_file()
-    concatenated_data = read_h5mu(output_path, backed=False)
-    data_sample1 = read_h5mu(edited_h5mu_path, backed=False)
-    data_sample2 = read_h5mu(small_mudata_mod2_path, backed=False)
-
-    expected_concatenated_data = MuData(
-        {"mod1": data_sample1.mod["mod1"], "mod2": data_sample2.mod["mod2"]}
-    )
-
-    assert set(concatenated_data.obs_names) == (
-        set(data_sample1.obs_names) | set(data_sample2.obs_names)
-    )
-    assert concatenated_data[removed_observation_name:]["mod1"].n_obs == 0
-    assert concatenated_data[removed_observation_name:]["mod2"].n_obs == 1
-
-    np.testing.assert_equal(
-        concatenated_data.copy()[removed_observation_name:]["mod2"].X.data,
-        data_sample2.copy()[removed_observation_name:]["mod2"].X.data,
-    )
-
-    assert_annotation_objects_equal(concatenated_data, expected_concatenated_data)
-
-
-@pytest.mark.parametrize(
-    "extra_var_column_name,extra_var_column_value,expected",
-    [
-        ("test", "bar", "bar"),
-        ("test", True, True),
-        ("test", 0.1, 0.1),
-        ("test", np.nan, pd.NA),
-    ],
-)
-@pytest.mark.parametrize(
-    "mudata_with_extra_var_column",
-    ["split_small_mudata_path"],
-    indirect=["mudata_with_extra_var_column"],
-)
-def test_boolean_and_na_types(
-    run_component,
-    mudata_with_extra_var_column,
-    extra_var_column_name,
-    expected,
-    random_h5mu_path,
-):
-    """
-    Test if merging booleans of NAs results in the .var .obs column being writeable
-    """
-    input_sample1_path, input_sample2_path = mudata_with_extra_var_column
-    output_path = random_h5mu_path()
-
-    run_component(
-        [
-            "--input",
-            input_sample1_path,
-            "--input",
-            input_sample2_path,
-            "--output",
-            output_path,
-        ]
-    )
-    assert output_path.is_file()
-    merged_data = read_h5mu(output_path, backed=False)
-    first_sample_mod = list(read_h5mu(input_sample1_path).mod)[0]
-    second_sample_mod = list(read_h5mu(input_sample2_path).mod)[0]
-
-    expected_merged_data = MuData(
-        {
-            "mod1": read_h5mu(input_sample1_path).mod["mod1"],
-            "mod2": read_h5mu(input_sample2_path).mod["mod2"],
+        # pd.convert_dtypes does not convert already existing nullable dtypes
+        # to their native numpy dtypes.
+        # At this point, integer and boolean columns use a nullable dtype; and string columns
+        # might use 'object' or pd.StringDtype. This is OK.
+        # However, for example floating number columns might still use a nullable dtype
+        # from before the call to convert_dtypes. So we need to explicitly cast.
+        col_dtypes = df.select_dtypes(
+            exclude=["integer", "string", "object", "boolean"]
+        ).dtypes.to_dict()
+        numpy_dtypes = {
+            col_name: np.dtype(col_dtype.kind)
+            for col_name, col_dtype in col_dtypes.items()
+            if pd.api.types.is_extension_array_dtype(col_dtype)
         }
-    )
+        df = df.astype(numpy_dtypes)
 
-    if not pd.isna(expected):
-        assert merged_data.var.loc["var1"][extra_var_column_name] == expected
-        assert (
-            merged_data.mod[first_sample_mod].var.loc["var1"][extra_var_column_name]
-            == expected
-        )
-    else:
-        assert pd.isna(merged_data.var.loc["var1"][extra_var_column_name])
-        assert pd.isna(
-            merged_data.mod[first_sample_mod].var.loc["var1"][extra_var_column_name]
-        )
-    assert pd.isna(merged_data.var.loc["var4"][extra_var_column_name])
-    assert pd.isna(
-        merged_data.mod[second_sample_mod].var.loc["var4"][extra_var_column_name]
-    )
+        # Convert leftover 'object' columns to string
+        object_cols = df.select_dtypes(include="object").columns.values
+        for obj_col in object_cols:
+            df[obj_col] = df[obj_col].astype(str).astype("category")
 
-    assert_annotation_objects_equal(merged_data, expected_merged_data)
+        setattr(merged, df_attr, df)
 
-
-def test_same_modalities_raises(
-    run_component, random_h5mu_path, split_small_mudata_path
-):
-    """
-    Raise when trying to merge modalities with the same name.
-    """
-    input_sample1_path, input_sample2_path = split_small_mudata_path
-    input_sample2_edited_path = random_h5mu_path()
-    output_path = random_h5mu_path()
-    data_sample2 = read_h5mu(input_sample2_path)
-    data_sample2 = MuData({"mod1": data_sample2.mod["mod2"]})
-    data_sample2.write(input_sample2_edited_path, compression="gzip")
-
-    with pytest.raises(subprocess.CalledProcessError) as err:
-        run_component(
-            [
-                "--input",
-                input_sample1_path,
-                "--input",
-                input_sample2_edited_path,
-                "--output",
-                output_path,
-            ]
-        )
-    assert re.search(
-        r"ValueError: Modality 'mod1' was found in more than 1 sample\.",
-        err.value.stdout.decode("utf-8"),
-    )
+    merged.write_h5mu(par["output"], compression=par["output_compression"])
+    logger.info("Finished")
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))
+    main()


### PR DESCRIPTION
## Changelog

Nullable Floats are not supported by MuData/AnnData - added logic to convert to numpy's float

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!