### PR TITLE
`from_h5mu_or_h5ad_to_tiledb`: fix using index as source for gene symbol.

### DIFF
--- a/src/convert/from_h5mu_or_h5ad_to_tiledb/script.py
+++ b/src/convert/from_h5mu_or_h5ad_to_tiledb/script.py
@@ -285,18 +285,24 @@ def _copy_column(src, dest, _, df_h5_obj):
     The input dataframe must be h5py object that is encoded by AnnData to store
     a pandas dataframe (e.g. .obs and .var).
     """
-    if src is None:
-        src = df_h5_obj.attrs["_index"]
     logger.info("Copying column '%s' to '%s' for '%s'.", src, dest, df_h5_obj.name)
+    columns = df_h5_obj.attrs["column-order"]
+    if dest in columns:
+        raise ValueError(f"Column {dest} already exists in {df_h5_obj.name}.")
     if src == dest:
         logger.info("Source and destination for the column are the same, not copying.")
         return None
-    if dest in df_h5_obj:
-        raise ValueError(f"Column {dest} already exists in {df_h5_obj.name}.")
-    df_h5_obj[dest] = src
-    column_order = df_h5_obj.attrs["column-order"]
-    if dest not in column_order:
-        df_h5_obj.attrs["column-order"] = np.append(column_order, dest)
+    df_h5_obj.attrs["column-order"] = np.append(columns, dest)
+    if src is None:
+        # Use the index as source.
+        src = df_h5_obj.attrs["_index"]
+        # Both the index and columns are written as keys to df_h5_obj
+        # An index name may be allowed to also be column name _only_ when
+        # the column and the index have the same contents (this is an anndata requirement).
+        # Here, this is always the case.
+        if src in df_h5_obj.attrs["column-order"]:
+            return None
+    df_h5_obj[dest] = df_h5_obj[src]
 
 
 def _set_index_name(name, _, df_h5_obj):
@@ -307,7 +313,14 @@ def _set_index_name(name, _, df_h5_obj):
     """
     logger.info("Setting index name of '%s' to '%s'.", df_h5_obj.name, name)
     original_index_name = df_h5_obj.attrs["_index"]
-    df_h5_obj.move(original_index_name, name)
+    # An index and a column may share a key in df_h5_obj
+    # In this case we must not remove the original key from the object
+    operator = (
+        df_h5_obj.move
+        if original_index_name not in df_h5_obj.attrs["column-order"]
+        else df_h5_obj.copy
+    )
+    operator(original_index_name, name)
     df_h5_obj.attrs["_index"] = name
     logger.info("Done setting index name")
 

--- a/src/convert/from_h5mu_or_h5ad_to_tiledb/test.py
+++ b/src/convert/from_h5mu_or_h5ad_to_tiledb/test.py
@@ -501,5 +501,50 @@ def test_convert_mudata(
             np.testing.assert_allclose(expected, contents)
 
 
+def test_gene_synbol_column_name_use_index(
+    run_component, sample_1_modality_1, random_h5ad_path, tmp_path
+):
+    output_path = tmp_path / "output"
+    input_h5ad = random_h5ad_path()
+    sample_1_modality_1.var.index.name = "gene_symbol"
+    sample_1_modality_1.write(input_h5ad)
+    run_component(
+        [
+            "--input",
+            input_h5ad,
+            "--rna_modality",
+            "mod1",
+            "--rna_raw_layer_input",
+            "X",
+            "--rna_normalized_layer_input",
+            "layer1",
+            "--tiledb_dir",
+            output_path,
+        ]
+    )
+    with tiledbsoma.DataFrame.open(f"{output_path}/ms/rna/var") as obs_arr:
+        var_contents = obs_arr.read().concat()
+        expected_schema = pa.schema(
+            [
+                pa.field("soma_joinid", pa.int64(), nullable=False),
+                pa.field("rna_index", pa.large_string()),
+                pa.field("Feat1", pa.large_string()),
+                pa.field("Shared_feat_col", pa.large_string()),
+                pa.field("gene_symbol", pa.large_string()),
+            ]
+        )
+        expected = pa.Table.from_arrays(
+            [
+                pa.array([0, 1, 2]),
+                pa.array(["var1", "var2", "overlapping_var_mod1"]),
+                pa.array(["a", "c", "e"]),
+                pa.array(["b", "d", "f"]),
+                pa.array(["var1", "var2", "overlapping_var_mod1"]),
+            ],
+            schema=expected_schema,
+        )
+        assert expected.equals(var_contents)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Changelog

`from_h5mu_or_h5ad_to_tiledb`: fix using index as source for gene_symbol

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!