### PR TITLE
TileDB conversion: fix error when gene symbol column is already present

### DIFF
--- a/src/convert/from_h5mu_or_h5ad_to_tiledb/script.py
+++ b/src/convert/from_h5mu_or_h5ad_to_tiledb/script.py
@@ -287,11 +287,11 @@ def _copy_column(src, dest, _, df_h5_obj):
     """
     logger.info("Copying column '%s' to '%s' for '%s'.", src, dest, df_h5_obj.name)
     columns = df_h5_obj.attrs["column-order"]
-    if dest in columns:
-        raise ValueError(f"Column {dest} already exists in {df_h5_obj.name}.")
     if src == dest:
         logger.info("Source and destination for the column are the same, not copying.")
         return None
+    if dest in columns:
+        raise ValueError(f"Column {dest} already exists in {df_h5_obj.name}.")
     df_h5_obj.attrs["column-order"] = np.append(columns, dest)
     if src is None:
         # Use the index as source.


### PR DESCRIPTION
## Changelog

TileDB conversion: fix error when gene symbol column is already present

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] ~Proposed changes are described in the CHANGELOG.md~ New component

- [x] CI tests succeed!