### PR TITLE
Add dataflow/move_anndata_slots component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * `dimred/pca`: added possibility to do chunked processing using arguments `chunks` and `chunk_size`. Also added a `seed` argument in order to better control the variability between executions (PR #1157).
 
+* `dataflow/move_anndata_slots`: added a component to selectively move AnnData slots from a modality in a source MuData file into a modality in a target MuData file (PR #1163).
+
 ## MAJOR CHANGES
 
 * `qc/calculate_qc_metrics`: major improvements to memory consumption and runtimes (PR #1140).

--- a/src/dataflow/move_anndata_slots/config.vsh.yaml
+++ b/src/dataflow/move_anndata_slots/config.vsh.yaml
@@ -8,7 +8,7 @@ description: |
   modality, overwriting any existing data at those slots.
 
 authors:
-  - __merge__: /src/authors/dorien_roosen.yaml
+  - __merge__: /src/authors/jakub_majercik.yaml
     roles: [ author ]
 
 argument_groups:
@@ -93,6 +93,15 @@ argument_groups:
         multiple: true
         required: false
 
+  - name: "Options"
+    arguments:
+      - name: "--allow_overwrite"
+        type: boolean_true
+        description: |
+          Allow overwriting keys that already exist in the target modality.
+          By default, the component raises an error if a key already exists.
+          When enabled, existing keys are overwritten with a warning.
+
   - name: "Output"
     arguments:
       - name: "--output"
@@ -116,7 +125,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: python:3.12-slim
+    image: python:3.13-slim
     setup:
       - type: apt
         packages:

--- a/src/dataflow/move_anndata_slots/config.vsh.yaml
+++ b/src/dataflow/move_anndata_slots/config.vsh.yaml
@@ -1,0 +1,132 @@
+name: move_anndata_slots
+namespace: "dataflow"
+scope: "public"
+description: |
+  Move slots (.obs, .var, .obsm, .varm, .obsp, .varp, .uns) from a modality
+  in a source MuData file into a modality in a target MuData file.
+  The specified slots are copied from the source modality into the target
+  modality, overwriting any existing data at those slots.
+
+authors:
+  - __merge__: /src/authors/dorien_roosen.yaml
+    roles: [ author ]
+
+argument_groups:
+  - name: "Source"
+    arguments:
+      - name: "--input_source"
+        type: file
+        description: Source h5mu file to read slots from.
+        direction: input
+        required: true
+        example: source.h5mu
+      - name: "--source_modality"
+        type: string
+        description: Modality in the source h5mu file to read slots from.
+        default: "rna"
+        required: false
+
+  - name: "Target"
+    arguments:
+      - name: "--input_target"
+        type: file
+        description: Target h5mu file to write slots into.
+        direction: input
+        required: true
+        example: target.h5mu
+      - name: "--target_modality"
+        type: string
+        description: |
+          Modality in the target h5mu file to write slots into.
+          Defaults to the value of --source_modality.
+        required: false
+
+  - name: "Slots to move"
+    arguments:
+      - name: "--obs"
+        type: string
+        description: |
+          Column names from .obs to move from the source modality to the
+          target modality. If not provided, .obs is not moved.
+        multiple: true
+        required: false
+      - name: "--var"
+        type: string
+        description: |
+          Column names from .var to move from the source modality to the
+          target modality. If not provided, .var is not moved.
+        multiple: true
+        required: false
+      - name: "--obsm"
+        type: string
+        description: |
+          Keys from .obsm to move from the source modality to the target
+          modality. If not provided, .obsm is not moved.
+        multiple: true
+        required: false
+      - name: "--varm"
+        type: string
+        description: |
+          Keys from .varm to move from the source modality to the target
+          modality. If not provided, .varm is not moved.
+        multiple: true
+        required: false
+      - name: "--obsp"
+        type: string
+        description: |
+          Keys from .obsp to move from the source modality to the target
+          modality. If not provided, .obsp is not moved.
+        multiple: true
+        required: false
+      - name: "--varp"
+        type: string
+        description: |
+          Keys from .varp to move from the source modality to the target
+          modality. If not provided, .varp is not moved.
+        multiple: true
+        required: false
+      - name: "--uns"
+        type: string
+        description: |
+          Keys from .uns to move from the source modality to the target
+          modality. If not provided, .uns is not moved.
+        multiple: true
+        required: false
+
+  - name: "Output"
+    arguments:
+      - name: "--output"
+        alternatives: ["-o"]
+        type: file
+        description: Output h5mu file (the target with slots added from the source).
+        direction: output
+        required: true
+        example: output.h5mu
+    __merge__: [., /src/base/h5_compression_argument.yaml]
+
+resources:
+  - type: python_script
+    path: script.py
+  - path: /src/utils/setup_logger.py
+  - path: /src/utils/compress_h5mu.py
+
+test_resources:
+  - type: python_script
+    path: test.py
+
+engines:
+  - type: docker
+    image: python:3.12-slim
+    setup:
+      - type: apt
+        packages:
+          - procps
+      - type: python
+        __merge__: /src/base/requirements/anndata_mudata.yaml
+    __merge__: [/src/base/requirements/python_test_setup.yaml, .]
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [ singlecpu, lowmem ]

--- a/src/dataflow/move_anndata_slots/script.py
+++ b/src/dataflow/move_anndata_slots/script.py
@@ -1,0 +1,116 @@
+import sys
+from mudata import read_h5ad
+
+## VIASH START
+par = {
+    "input_source": "source.h5mu",
+    "source_modality": "rna",
+    "input_target": "target.h5mu",
+    "target_modality": None,
+    "obs": None,
+    "var": None,
+    "obsm": None,
+    "varm": None,
+    "obsp": None,
+    "varp": None,
+    "uns": None,
+    "output": "output.h5mu",
+    "output_compression": None,
+}
+meta = {"resources_dir": "src/utils/"}
+## VIASH END
+
+sys.path.append(meta["resources_dir"])
+from setup_logger import setup_logger
+from compress_h5mu import write_h5ad_to_h5mu_with_compression
+
+logger = setup_logger()
+
+target_modality = par["target_modality"] or par["source_modality"]
+
+logger.info(
+    "Reading modality '%s' from source file '%s'",
+    par["source_modality"],
+    par["input_source"],
+)
+try:
+    source_mod = read_h5ad(par["input_source"], mod=par["source_modality"])
+except KeyError:
+    raise ValueError(
+        f"Modality '{par['source_modality']}' does not exist in source file "
+        f"'{par['input_source']}'."
+    )
+
+logger.info(
+    "Reading modality '%s' from target file '%s'",
+    target_modality,
+    par["input_target"],
+)
+try:
+    target_mod = read_h5ad(par["input_target"], mod=target_modality)
+except KeyError:
+    raise ValueError(
+        f"Modality '{target_modality}' does not exist in target file "
+        f"'{par['input_target']}'."
+    )
+
+# .obs columns
+if par["obs"]:
+    missing = [col for col in par["obs"] if col not in source_mod.obs.columns]
+    if missing:
+        raise ValueError(
+            f"The following .obs columns were not found in source modality "
+            f"'{par['source_modality']}': {missing}"
+        )
+    logger.info("Moving .obs columns: %s", par["obs"])
+    for col in par["obs"]:
+        target_mod.obs[col] = source_mod.obs[col]
+
+# .var columns
+if par["var"]:
+    missing = [col for col in par["var"] if col not in source_mod.var.columns]
+    if missing:
+        raise ValueError(
+            f"The following .var columns were not found in source modality "
+            f"'{par['source_modality']}': {missing}"
+        )
+    logger.info("Moving .var columns: %s", par["var"])
+    for col in par["var"]:
+        target_mod.var[col] = source_mod.var[col]
+
+# Dict-like slots: .obsm, .varm, .obsp, .varp, .uns
+_dict_slots = [
+    ("obsm", par["obsm"]),
+    ("varm", par["varm"]),
+    ("obsp", par["obsp"]),
+    ("varp", par["varp"]),
+    ("uns", par["uns"]),
+]
+
+for slot_name, keys in _dict_slots:
+    if not keys:
+        continue
+    source_slot = getattr(source_mod, slot_name)
+    target_slot = getattr(target_mod, slot_name)
+    missing = [k for k in keys if k not in source_slot]
+    if missing:
+        raise ValueError(
+            f"The following .{slot_name} keys were not found in source "
+            f"modality '{par['source_modality']}': {missing}"
+        )
+    logger.info("Moving .%s keys: %s", slot_name, keys)
+    for key in keys:
+        target_slot[key] = source_slot[key]
+
+logger.info(
+    "Writing output to '%s' with compression '%s'",
+    par["output"],
+    par["output_compression"],
+)
+write_h5ad_to_h5mu_with_compression(
+    output_file=par["output"],
+    h5mu=par["input_target"],
+    modality_name=target_modality,
+    modality_data=target_mod,
+    output_compression=par["output_compression"],
+)

--- a/src/dataflow/move_anndata_slots/script.py
+++ b/src/dataflow/move_anndata_slots/script.py
@@ -55,6 +55,30 @@ except KeyError:
         f"'{par['input_target']}'."
     )
 
+# Validate indices for the axes relevant to the requested slots.
+needs_obs = any(par[s] for s in ("obs", "obsm", "obsp"))
+needs_var = any(par[s] for s in ("var", "varm", "varp"))
+
+mismatches = []
+if needs_obs and set(source_mod.obs_names) != set(target_mod.obs_names):
+    mismatches.append("obs")
+if needs_var and set(source_mod.var_names) != set(target_mod.var_names):
+    mismatches.append("var")
+if mismatches:
+    raise ValueError(
+        "Index mismatch between source and target modalities: "
+        + " and ".join(mismatches)
+        + " indices do not match."
+    )
+
+# Reindex source to match target order if needed.
+if needs_obs and not (source_mod.obs_names == target_mod.obs_names).all():
+    logger.info("Reindexing source observations to match target order.")
+    source_mod = source_mod[target_mod.obs_names, :]
+if needs_var and not (source_mod.var_names == target_mod.var_names).all():
+    logger.info("Reindexing source variables to match target order.")
+    source_mod = source_mod[:, target_mod.var_names]
+
 # .obs/.var are DataFrames (column access), .obsm/.varm/.obsp/.varp are array
 # containers, and .uns is a dict -- all support key-based get/set via getattr.
 _slots = [

--- a/src/dataflow/move_anndata_slots/script.py
+++ b/src/dataflow/move_anndata_slots/script.py
@@ -14,6 +14,7 @@ par = {
     "obsp": None,
     "varp": None,
     "uns": None,
+    "allow_overwrite": False,
     "output": "output.h5mu",
     "output_compression": None,
 }
@@ -54,32 +55,11 @@ except KeyError:
         f"'{par['input_target']}'."
     )
 
-# .obs columns
-if par["obs"]:
-    missing = [col for col in par["obs"] if col not in source_mod.obs.columns]
-    if missing:
-        raise ValueError(
-            f"The following .obs columns were not found in source modality "
-            f"'{par['source_modality']}': {missing}"
-        )
-    logger.info("Moving .obs columns: %s", par["obs"])
-    for col in par["obs"]:
-        target_mod.obs[col] = source_mod.obs[col]
-
-# .var columns
-if par["var"]:
-    missing = [col for col in par["var"] if col not in source_mod.var.columns]
-    if missing:
-        raise ValueError(
-            f"The following .var columns were not found in source modality "
-            f"'{par['source_modality']}': {missing}"
-        )
-    logger.info("Moving .var columns: %s", par["var"])
-    for col in par["var"]:
-        target_mod.var[col] = source_mod.var[col]
-
-# Dict-like slots: .obsm, .varm, .obsp, .varp, .uns
-_dict_slots = [
+# .obs/.var are DataFrames (column access), .obsm/.varm/.obsp/.varp are array
+# containers, and .uns is a dict — but all support key-based get/set via getattr.
+_slots = [
+    ("obs", par["obs"]),
+    ("var", par["var"]),
     ("obsm", par["obsm"]),
     ("varm", par["varm"]),
     ("obsp", par["obsp"]),
@@ -87,7 +67,7 @@ _dict_slots = [
     ("uns", par["uns"]),
 ]
 
-for slot_name, keys in _dict_slots:
+for slot_name, keys in _slots:
     if not keys:
         continue
     source_slot = getattr(source_mod, slot_name)
@@ -98,6 +78,16 @@ for slot_name, keys in _dict_slots:
             f"The following .{slot_name} keys were not found in source "
             f"modality '{par['source_modality']}': {missing}"
         )
+    existing = [k for k in keys if k in target_slot]
+    if existing and not par["allow_overwrite"]:
+        raise ValueError(
+            f"The following .{slot_name} keys already exist in the target "
+            f"modality '{target_modality}': {existing}. "
+            f"Use --allow_overwrite to overwrite them."
+        )
+    if existing:
+        logger.warning("Overwriting existing .%s keys: %s", slot_name, existing)
+
     logger.info("Moving .%s keys: %s", slot_name, keys)
     for key in keys:
         target_slot[key] = source_slot[key]

--- a/src/dataflow/move_anndata_slots/script.py
+++ b/src/dataflow/move_anndata_slots/script.py
@@ -56,7 +56,7 @@ except KeyError:
     )
 
 # .obs/.var are DataFrames (column access), .obsm/.varm/.obsp/.varp are array
-# containers, and .uns is a dict — but all support key-based get/set via getattr.
+# containers, and .uns is a dict -- all support key-based get/set via getattr.
 _slots = [
     ("obs", par["obs"]),
     ("var", par["var"]),

--- a/src/dataflow/move_anndata_slots/test.py
+++ b/src/dataflow/move_anndata_slots/test.py
@@ -1,0 +1,375 @@
+import sys
+import subprocess
+import re
+
+import pytest
+import mudata as mu
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+
+@pytest.fixture
+def source_modality():
+    """Source AnnData with obs, var, obsm, varm, obsp, varp, and uns."""
+    X = pd.DataFrame(
+        [[1, 2, 3], [4, 5, 6]],
+        index=["obs1", "obs2"],
+        columns=["var1", "var2", "var3"],
+    )
+    obs = pd.DataFrame(
+        {"cell_type": ["T-cell", "B-cell"], "score": [0.9, 0.8]},
+        index=X.index,
+    )
+    var = pd.DataFrame(
+        {"gene_name": ["GeneA", "GeneB", "GeneC"], "dispersions": [1.1, 2.2, 3.3]},
+        index=X.columns,
+    )
+    adata = ad.AnnData(X, obs=obs, var=var)
+    adata.obsm["X_pca"] = np.array([[0.1, 0.2], [0.3, 0.4]])
+    adata.varm["PCs"] = np.array([[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]])
+    adata.obsp["distances"] = sp.csr_matrix(np.array([[0.0, 1.0], [1.0, 0.0]]))
+    adata.varp["correlations"] = sp.csr_matrix(
+        np.array([[1.0, 0.5, 0.2], [0.5, 1.0, 0.3], [0.2, 0.3, 1.0]])
+    )
+    adata.uns["method"] = "custom_pipeline"
+    adata.uns["params"] = {"n_neighbors": 15}
+    return adata
+
+
+@pytest.fixture
+def target_modality():
+    """Target AnnData with the same observations and variables but different annotations."""
+    X = pd.DataFrame(
+        [[10, 20, 30], [40, 50, 60]],
+        index=["obs1", "obs2"],
+        columns=["var1", "var2", "var3"],
+    )
+    obs = pd.DataFrame(
+        {"batch": ["A", "B"]},
+        index=X.index,
+    )
+    var = pd.DataFrame(
+        {"highly_variable": [True, False, True]},
+        index=X.columns,
+    )
+    return ad.AnnData(X, obs=obs, var=var)
+
+
+@pytest.fixture
+def other_modality():
+    """A second modality in the target file that should remain untouched."""
+    X = pd.DataFrame(
+        [[100, 200], [300, 400]],
+        index=["obs1", "obs2"],
+        columns=["protA", "protB"],
+    )
+    return ad.AnnData(X)
+
+
+@pytest.fixture
+def source_h5mu_path(write_mudata_to_file, source_modality):
+    mdata = mu.MuData({"rna": source_modality})
+    return write_mudata_to_file(mdata)
+
+
+@pytest.fixture
+def target_h5mu_path(write_mudata_to_file, target_modality, other_modality):
+    mdata = mu.MuData({"rna": target_modality, "prot": other_modality})
+    return write_mudata_to_file(mdata)
+
+
+def test_move_obs_columns(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move selected .obs columns from source to target."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--obs", "cell_type",
+            "--output", str(output),
+        ]
+    )
+    assert output.is_file()
+
+    result = mu.read_h5mu(output)
+    rna = result.mod["rna"]
+
+    # Moved column is present
+    assert "cell_type" in rna.obs.columns
+    assert list(rna.obs["cell_type"]) == ["T-cell", "B-cell"]
+
+    # Non-requested column was NOT moved
+    assert "score" not in rna.obs.columns
+
+    # Pre-existing target column is preserved
+    assert "batch" in rna.obs.columns
+
+    # Other modality is untouched
+    assert "prot" in result.mod
+    assert result.mod["prot"].n_vars == 2
+
+
+def test_move_var_columns(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move selected .var columns from source to target."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--var", "gene_name", "--var", "dispersions",
+            "--output", str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+
+    assert "gene_name" in rna.var.columns
+    assert "dispersions" in rna.var.columns
+    assert list(rna.var["gene_name"]) == ["GeneA", "GeneB", "GeneC"]
+
+    # Pre-existing target column preserved
+    assert "highly_variable" in rna.var.columns
+
+
+def test_move_obsm_and_uns(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move .obsm and .uns keys from source to target."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--obsm", "X_pca",
+            "--uns", "method",
+            "--output", str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+
+    assert "X_pca" in rna.obsm
+    np.testing.assert_array_almost_equal(
+        rna.obsm["X_pca"], np.array([[0.1, 0.2], [0.3, 0.4]])
+    )
+    assert rna.uns["method"] == "custom_pipeline"
+
+    # uns key not requested should not appear
+    assert "params" not in rna.uns
+
+
+def test_move_varm_obsp_varp(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move .varm, .obsp, and .varp keys from source to target."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--varm", "PCs",
+            "--obsp", "distances",
+            "--varp", "correlations",
+            "--output", str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+
+    assert "PCs" in rna.varm
+    np.testing.assert_array_almost_equal(
+        rna.varm["PCs"], np.array([[0.5, 0.6], [0.7, 0.8], [0.9, 1.0]])
+    )
+    assert "distances" in rna.obsp
+    assert rna.obsp["distances"].shape == (2, 2)
+    assert "correlations" in rna.varp
+    assert rna.varp["correlations"].shape == (3, 3)
+
+
+def test_move_all_slots(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move at least one key from every slot type in a single invocation."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--obs", "cell_type",
+            "--var", "gene_name",
+            "--obsm", "X_pca",
+            "--varm", "PCs",
+            "--obsp", "distances",
+            "--varp", "correlations",
+            "--uns", "method",
+            "--output", str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+
+    assert "cell_type" in rna.obs.columns
+    assert "gene_name" in rna.var.columns
+    assert "X_pca" in rna.obsm
+    assert "PCs" in rna.varm
+    assert "distances" in rna.obsp
+    assert "correlations" in rna.varp
+    assert rna.uns["method"] == "custom_pipeline"
+
+
+def test_target_modality_defaults_to_source(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """When --target_modality is not set, it defaults to --source_modality."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_h5mu_path),
+            "--input_target", str(target_h5mu_path),
+            "--source_modality", "rna",
+            "--obs", "cell_type",
+            "--output", str(output),
+        ]
+    )
+    result = mu.read_h5mu(output)
+    assert "cell_type" in result.mod["rna"].obs.columns
+
+
+def test_cross_modality_move(
+    run_component, random_path, write_mudata_to_file, source_modality, other_modality
+):
+    """Move from rna modality in source to prot modality in target using --target_modality."""
+    # Source has rna with obs columns
+    source_path = write_mudata_to_file(mu.MuData({"rna": source_modality}))
+
+    # Target has prot modality with same observations
+    prot = ad.AnnData(
+        pd.DataFrame(
+            [[100, 200], [300, 400]],
+            index=["obs1", "obs2"],
+            columns=["protA", "protB"],
+        )
+    )
+    target_path = write_mudata_to_file(mu.MuData({"prot": prot}))
+
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_path),
+            "--input_target", str(target_path),
+            "--source_modality", "rna",
+            "--target_modality", "prot",
+            "--obs", "cell_type",
+            "--output", str(output),
+        ]
+    )
+    result = mu.read_h5mu(output)
+    assert "cell_type" in result.mod["prot"].obs.columns
+    assert list(result.mod["prot"].obs["cell_type"]) == ["T-cell", "B-cell"]
+
+
+def test_missing_obs_column_raises_error(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Requesting a non-existent .obs column should fail with a clear error."""
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source", str(source_h5mu_path),
+                "--input_target", str(target_h5mu_path),
+                "--source_modality", "rna",
+                "--obs", "nonexistent_column",
+                "--output", str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*\.obs columns were not found.*nonexistent_column",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_missing_obsm_key_raises_error(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Requesting a non-existent .obsm key should fail with a clear error."""
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source", str(source_h5mu_path),
+                "--input_target", str(target_h5mu_path),
+                "--source_modality", "rna",
+                "--obsm", "X_umap",
+                "--output", str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*\.obsm keys were not found.*X_umap",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_missing_source_modality_raises_error(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Requesting a non-existent source modality should fail with a clear error."""
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source", str(source_h5mu_path),
+                "--input_target", str(target_h5mu_path),
+                "--source_modality", "nonexistent",
+                "--obs", "cell_type",
+                "--output", str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*nonexistent.*does not exist in source file",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_overwrites_existing_slot(
+    run_component, random_path, write_mudata_to_file, source_modality
+):
+    """Moving a column that already exists in the target should overwrite it."""
+    # Target already has a "cell_type" column with different values
+    target_adata = ad.AnnData(
+        pd.DataFrame(
+            [[10, 20, 30], [40, 50, 60]],
+            index=["obs1", "obs2"],
+            columns=["var1", "var2", "var3"],
+        ),
+        obs=pd.DataFrame(
+            {"cell_type": ["old_A", "old_B"]},
+            index=["obs1", "obs2"],
+        ),
+    )
+    source_path = write_mudata_to_file(mu.MuData({"rna": source_modality}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target_adata}))
+
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source", str(source_path),
+            "--input_target", str(target_path),
+            "--source_modality", "rna",
+            "--obs", "cell_type",
+            "--output", str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+    assert list(rna.obs["cell_type"]) == ["T-cell", "B-cell"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/src/dataflow/move_anndata_slots/test.py
+++ b/src/dataflow/move_anndata_slots/test.py
@@ -572,5 +572,126 @@ def test_move_categorical_and_string_obs(
     assert list(rna.obs["description"]) == ["first sample", "second sample"]
 
 
+def test_mismatched_obs_indices_raises_error(
+    run_component, random_path, write_mudata_to_file
+):
+    """Source and target with different observation IDs should error."""
+    source = ad.AnnData(
+        pd.DataFrame([[1, 2]], index=["cellA"], columns=["var1", "var2"]),
+        obs=pd.DataFrame({"score": [0.5]}, index=["cellA"]),
+    )
+    target = ad.AnnData(
+        pd.DataFrame([[3, 4]], index=["cellX"], columns=["var1", "var2"]),
+    )
+    source_path = write_mudata_to_file(mu.MuData({"rna": source}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target}))
+
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source",
+                str(source_path),
+                "--input_target",
+                str(target_path),
+                "--source_modality",
+                "rna",
+                "--obs",
+                "score",
+                "--output",
+                str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*Index mismatch.*obs",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_mismatched_var_indices_raises_error(
+    run_component, random_path, write_mudata_to_file
+):
+    """Source and target with different variable IDs should error."""
+    source = ad.AnnData(
+        pd.DataFrame([[1, 2]], index=["obs1"], columns=["geneA", "geneB"]),
+        var=pd.DataFrame({"name": ["A", "B"]}, index=["geneA", "geneB"]),
+    )
+    target = ad.AnnData(
+        pd.DataFrame([[3, 4]], index=["obs1"], columns=["geneX", "geneY"]),
+    )
+    source_path = write_mudata_to_file(mu.MuData({"rna": source}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target}))
+
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source",
+                str(source_path),
+                "--input_target",
+                str(target_path),
+                "--source_modality",
+                "rna",
+                "--var",
+                "name",
+                "--output",
+                str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*Index mismatch.*var",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_reindexes_when_order_differs(run_component, random_path, write_mudata_to_file):
+    """Source and target with same IDs but different order should align correctly."""
+    source = ad.AnnData(
+        pd.DataFrame(
+            [[1, 2], [3, 4]],
+            index=["obs2", "obs1"],
+            columns=["var1", "var2"],
+        ),
+        obs=pd.DataFrame({"label": ["second", "first"]}, index=["obs2", "obs1"]),
+    )
+    source.obsm["X_pca"] = np.array([[0.2, 0.2], [0.1, 0.1]])
+
+    target = ad.AnnData(
+        pd.DataFrame(
+            [[10, 20], [30, 40]],
+            index=["obs1", "obs2"],
+            columns=["var1", "var2"],
+        ),
+    )
+    source_path = write_mudata_to_file(mu.MuData({"rna": source}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target}))
+
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source",
+            str(source_path),
+            "--input_target",
+            str(target_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "label",
+            "--obsm",
+            "X_pca",
+            "--output",
+            str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+
+    # obs1 should get "first", obs2 should get "second" (aligned by index, not position)
+    assert list(rna.obs["label"]) == ["first", "second"]
+    # obsm should also be reindexed: obs1 -> [0.1, 0.1], obs2 -> [0.2, 0.2]
+    np.testing.assert_array_almost_equal(
+        rna.obsm["X_pca"], np.array([[0.1, 0.1], [0.2, 0.2]])
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/src/dataflow/move_anndata_slots/test.py
+++ b/src/dataflow/move_anndata_slots/test.py
@@ -87,11 +87,16 @@ def test_move_obs_columns(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--obs", "cell_type",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "cell_type",
+            "--output",
+            str(output),
         ]
     )
     assert output.is_file()
@@ -121,11 +126,18 @@ def test_move_var_columns(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--var", "gene_name", "--var", "dispersions",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--var",
+            "gene_name",
+            "--var",
+            "dispersions",
+            "--output",
+            str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]
@@ -145,12 +157,18 @@ def test_move_obsm_and_uns(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--obsm", "X_pca",
-            "--uns", "method",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--obsm",
+            "X_pca",
+            "--uns",
+            "method",
+            "--output",
+            str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]
@@ -172,13 +190,20 @@ def test_move_varm_obsp_varp(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--varm", "PCs",
-            "--obsp", "distances",
-            "--varp", "correlations",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--varm",
+            "PCs",
+            "--obsp",
+            "distances",
+            "--varp",
+            "correlations",
+            "--output",
+            str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]
@@ -193,24 +218,33 @@ def test_move_varm_obsp_varp(
     assert rna.varp["correlations"].shape == (3, 3)
 
 
-def test_move_all_slots(
-    run_component, random_path, source_h5mu_path, target_h5mu_path
-):
+def test_move_all_slots(run_component, random_path, source_h5mu_path, target_h5mu_path):
     """Move at least one key from every slot type in a single invocation."""
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--obs", "cell_type",
-            "--var", "gene_name",
-            "--obsm", "X_pca",
-            "--varm", "PCs",
-            "--obsp", "distances",
-            "--varp", "correlations",
-            "--uns", "method",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "cell_type",
+            "--var",
+            "gene_name",
+            "--obsm",
+            "X_pca",
+            "--varm",
+            "PCs",
+            "--obsp",
+            "distances",
+            "--varp",
+            "correlations",
+            "--uns",
+            "method",
+            "--output",
+            str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]
@@ -231,11 +265,16 @@ def test_target_modality_defaults_to_source(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_h5mu_path),
-            "--input_target", str(target_h5mu_path),
-            "--source_modality", "rna",
-            "--obs", "cell_type",
-            "--output", str(output),
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "cell_type",
+            "--output",
+            str(output),
         ]
     )
     result = mu.read_h5mu(output)
@@ -262,12 +301,18 @@ def test_cross_modality_move(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_path),
-            "--input_target", str(target_path),
-            "--source_modality", "rna",
-            "--target_modality", "prot",
-            "--obs", "cell_type",
-            "--output", str(output),
+            "--input_source",
+            str(source_path),
+            "--input_target",
+            str(target_path),
+            "--source_modality",
+            "rna",
+            "--target_modality",
+            "prot",
+            "--obs",
+            "cell_type",
+            "--output",
+            str(output),
         ]
     )
     result = mu.read_h5mu(output)
@@ -283,11 +328,16 @@ def test_missing_obs_column_raises_error(
     with pytest.raises(subprocess.CalledProcessError) as err:
         run_component(
             [
-                "--input_source", str(source_h5mu_path),
-                "--input_target", str(target_h5mu_path),
-                "--source_modality", "rna",
-                "--obs", "nonexistent_column",
-                "--output", str(output),
+                "--input_source",
+                str(source_h5mu_path),
+                "--input_target",
+                str(target_h5mu_path),
+                "--source_modality",
+                "rna",
+                "--obs",
+                "nonexistent_column",
+                "--output",
+                str(output),
             ]
         )
     assert re.search(
@@ -304,11 +354,16 @@ def test_missing_obsm_key_raises_error(
     with pytest.raises(subprocess.CalledProcessError) as err:
         run_component(
             [
-                "--input_source", str(source_h5mu_path),
-                "--input_target", str(target_h5mu_path),
-                "--source_modality", "rna",
-                "--obsm", "X_umap",
-                "--output", str(output),
+                "--input_source",
+                str(source_h5mu_path),
+                "--input_target",
+                str(target_h5mu_path),
+                "--source_modality",
+                "rna",
+                "--obsm",
+                "X_umap",
+                "--output",
+                str(output),
             ]
         )
     assert re.search(
@@ -325,11 +380,16 @@ def test_missing_source_modality_raises_error(
     with pytest.raises(subprocess.CalledProcessError) as err:
         run_component(
             [
-                "--input_source", str(source_h5mu_path),
-                "--input_target", str(target_h5mu_path),
-                "--source_modality", "nonexistent",
-                "--obs", "cell_type",
-                "--output", str(output),
+                "--input_source",
+                str(source_h5mu_path),
+                "--input_target",
+                str(target_h5mu_path),
+                "--source_modality",
+                "nonexistent",
+                "--obs",
+                "cell_type",
+                "--output",
+                str(output),
             ]
         )
     assert re.search(
@@ -360,11 +420,16 @@ def test_overwrites_existing_slot(
     output = random_path(extension="h5mu")
     run_component(
         [
-            "--input_source", str(source_path),
-            "--input_target", str(target_path),
-            "--source_modality", "rna",
-            "--obs", "cell_type",
-            "--output", str(output),
+            "--input_source",
+            str(source_path),
+            "--input_target",
+            str(target_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "cell_type",
+            "--output",
+            str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]

--- a/src/dataflow/move_anndata_slots/test.py
+++ b/src/dataflow/move_anndata_slots/test.py
@@ -341,7 +341,7 @@ def test_missing_obs_column_raises_error(
             ]
         )
     assert re.search(
-        r"ValueError.*\.obs columns were not found.*nonexistent_column",
+        r"ValueError.*\.obs keys were not found.*nonexistent_column",
         err.value.stdout.decode("utf-8"),
     )
 
@@ -398,11 +398,9 @@ def test_missing_source_modality_raises_error(
     )
 
 
-def test_overwrites_existing_slot(
-    run_component, random_path, write_mudata_to_file, source_modality
-):
-    """Moving a column that already exists in the target should overwrite it."""
-    # Target already has a "cell_type" column with different values
+@pytest.fixture
+def overwrite_fixture(write_mudata_to_file, source_modality):
+    """Source and target where target already has a 'cell_type' obs column."""
     target_adata = ad.AnnData(
         pd.DataFrame(
             [[10, 20, 30], [40, 50, 60]],
@@ -416,7 +414,37 @@ def test_overwrites_existing_slot(
     )
     source_path = write_mudata_to_file(mu.MuData({"rna": source_modality}))
     target_path = write_mudata_to_file(mu.MuData({"rna": target_adata}))
+    return source_path, target_path
 
+
+def test_overwrite_errors_by_default(run_component, random_path, overwrite_fixture):
+    """Overwriting an existing key should error when --allow_overwrite is not set."""
+    source_path, target_path = overwrite_fixture
+    output = random_path(extension="h5mu")
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        run_component(
+            [
+                "--input_source",
+                str(source_path),
+                "--input_target",
+                str(target_path),
+                "--source_modality",
+                "rna",
+                "--obs",
+                "cell_type",
+                "--output",
+                str(output),
+            ]
+        )
+    assert re.search(
+        r"ValueError.*\.obs keys already exist.*cell_type",
+        err.value.stdout.decode("utf-8"),
+    )
+
+
+def test_overwrite_with_allow_flag(run_component, random_path, overwrite_fixture):
+    """With --allow_overwrite, existing keys are overwritten successfully."""
+    source_path, target_path = overwrite_fixture
     output = random_path(extension="h5mu")
     run_component(
         [
@@ -428,12 +456,120 @@ def test_overwrites_existing_slot(
             "rna",
             "--obs",
             "cell_type",
+            "--allow_overwrite",
             "--output",
             str(output),
         ]
     )
     rna = mu.read_h5mu(output).mod["rna"]
     assert list(rna.obs["cell_type"]) == ["T-cell", "B-cell"]
+
+
+def test_move_multiple_obs_columns(
+    run_component, random_path, source_h5mu_path, target_h5mu_path
+):
+    """Move multiple .obs columns in one invocation."""
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source",
+            str(source_h5mu_path),
+            "--input_target",
+            str(target_h5mu_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "cell_type",
+            "--obs",
+            "score",
+            "--output",
+            str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+    assert "cell_type" in rna.obs.columns
+    assert "score" in rna.obs.columns
+    assert list(rna.obs["cell_type"]) == ["T-cell", "B-cell"]
+    assert list(rna.obs["score"]) == [0.9, 0.8]
+
+
+def test_move_multiple_obsm_keys(
+    run_component, random_path, write_mudata_to_file, target_modality
+):
+    """Move multiple .obsm keys in one invocation."""
+    source_adata = ad.AnnData(
+        pd.DataFrame(
+            [[1, 2, 3], [4, 5, 6]],
+            index=["obs1", "obs2"],
+            columns=["var1", "var2", "var3"],
+        )
+    )
+    source_adata.obsm["X_pca"] = np.array([[0.1, 0.2], [0.3, 0.4]])
+    source_adata.obsm["X_umap"] = np.array([[1.0, 2.0], [3.0, 4.0]])
+    source_path = write_mudata_to_file(mu.MuData({"rna": source_adata}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target_modality}))
+
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source",
+            str(source_path),
+            "--input_target",
+            str(target_path),
+            "--source_modality",
+            "rna",
+            "--obsm",
+            "X_pca",
+            "--obsm",
+            "X_umap",
+            "--output",
+            str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+    assert "X_pca" in rna.obsm
+    assert "X_umap" in rna.obsm
+    np.testing.assert_array_almost_equal(
+        rna.obsm["X_umap"], np.array([[1.0, 2.0], [3.0, 4.0]])
+    )
+
+
+def test_move_categorical_and_string_obs(
+    run_component, random_path, write_mudata_to_file, target_modality
+):
+    """Move .obs columns containing categorical and string data."""
+    source_adata = ad.AnnData(
+        pd.DataFrame(
+            [[1, 2, 3], [4, 5, 6]],
+            index=["obs1", "obs2"],
+            columns=["var1", "var2", "var3"],
+        )
+    )
+    source_adata.obs["label"] = pd.Categorical(["cluster_A", "cluster_B"])
+    source_adata.obs["description"] = ["first sample", "second sample"]
+    source_path = write_mudata_to_file(mu.MuData({"rna": source_adata}))
+    target_path = write_mudata_to_file(mu.MuData({"rna": target_modality}))
+
+    output = random_path(extension="h5mu")
+    run_component(
+        [
+            "--input_source",
+            str(source_path),
+            "--input_target",
+            str(target_path),
+            "--source_modality",
+            "rna",
+            "--obs",
+            "label",
+            "--obs",
+            "description",
+            "--output",
+            str(output),
+        ]
+    )
+    rna = mu.read_h5mu(output).mod["rna"]
+    assert list(rna.obs["label"]) == ["cluster_A", "cluster_B"]
+    assert list(rna.obs["description"]) == ["first sample", "second sample"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changelog

Add a new `dataflow/move_anndata_slots` component that selectively moves AnnData slots (`.obs`, `.var`, `.obsm`, `.varm`, `.obsp`, `.varp`, `.uns`) from a modality in a source MuData file into a modality in a target MuData file, without performing a full merge. Supports cross-modality transfers via `--target_modality`.

## Issue ticket number and link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!