### PR TITLE
Add `clear_slots` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * `workflows/multiomics/process_singlesample`: New workflow for processing RNA, protein and GDO modalities of individual samples (PR #1147).
 
+* `transform/clear_slots`: New component that can be used to remove all items from slots of a MuData object (PR #1171).
+
 ## MAJOR CHANGES
 
 * `qc/calculate_qc_metrics`: major improvements to memory consumption and runtimes (PR #1140).

--- a/src/transform/clear_slots/config.vsh.yaml
+++ b/src/transform/clear_slots/config.vsh.yaml
@@ -1,0 +1,61 @@
+name: clear_slots
+namespace: "transform"
+scope: "public"
+description: |
+  Clear one or more AnnData slot containers from a modality in an h5mu file.
+
+arguments:
+  - name: "--input"
+    alternatives: ["-i"]
+    type: file
+    description: Input h5mu file.
+    direction: input
+    required: true
+    example: input.h5mu
+  - name: "--modality"
+    type: string
+    description: Which modality from the input MuData file to process.
+    default: "rna"
+    required: false
+  - name: "--slots"
+    type: string
+    multiple: true
+    required: true
+    choices: [obsm, varm, obsp, varp, uns, layers]
+    description: |
+      Names of the AnnData slot families to clear from the selected modality.
+  - name: "--output"
+    alternatives: ["-o"]
+    type: file
+    description: Output h5mu file.
+    direction: output
+    required: true
+    default: output.h5mu
+__merge__: [., /src/base/h5_compression_argument.yaml]
+
+resources:
+  - type: python_script
+    path: script.py
+  - path: /src/utils/setup_logger.py
+  - path: /src/utils/compress_h5mu.py
+
+test_resources:
+  - type: python_script
+    path: test.py
+
+engines:
+  - type: docker
+    image: python:3.12-slim
+    setup:
+      - type: apt
+        packages:
+          - procps
+      - type: python
+        __merge__: /src/base/requirements/anndata_mudata.yaml
+    __merge__: [ /src/base/requirements/python_test_setup.yaml, .]
+
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: [singlecpu, lowmem]

--- a/src/transform/clear_slots/config.vsh.yaml
+++ b/src/transform/clear_slots/config.vsh.yaml
@@ -42,6 +42,8 @@ resources:
 test_resources:
   - type: python_script
     path: test.py
+  - path: /resources_test/annotation_test_data/
+  - path: /resources_test/pbmc_1k_protein_v3/
 
 engines:
   - type: docker

--- a/src/transform/clear_slots/script.py
+++ b/src/transform/clear_slots/script.py
@@ -1,4 +1,7 @@
 import sys
+from pathlib import Path
+
+from mudata import read_h5ad
 
 ## VIASH START
 par = {
@@ -12,6 +15,7 @@ meta = {"resources_dir": "src/utils"}
 ## VIASH END
 
 sys.path.append(meta["resources_dir"])
+from compress_h5mu import write_h5ad_to_h5mu_with_compression
 from setup_logger import setup_logger
 
 
@@ -19,7 +23,26 @@ logger = setup_logger()
 
 
 def main(par):
-    logger.info("clear_slots scaffold placeholder")
+    input_file = Path(par["input"])
+    output_file = Path(par["output"])
+    mod_name = par["modality"]
+
+    logger.info("Reading input file %s, modality %s.", input_file, mod_name)
+    mod = read_h5ad(input_file, mod=mod_name)
+
+    for slot in par["slots"]:
+        if not hasattr(mod, slot):
+            raise ValueError(f"Slot '{slot}' is not supported for modality {mod_name}.")
+
+        logger.info("Clearing %s from modality %s.", slot, mod_name)
+        getattr(mod, slot).clear()
+
+    logger.info("Writing output to %s.", output_file)
+    write_h5ad_to_h5mu_with_compression(
+        output_file, input_file, mod_name, mod, par["output_compression"]
+    )
+
+    logger.info("Done.")
 
 
 if __name__ == "__main__":

--- a/src/transform/clear_slots/script.py
+++ b/src/transform/clear_slots/script.py
@@ -1,0 +1,26 @@
+import sys
+
+## VIASH START
+par = {
+    "input": "input.h5mu",
+    "output": "output.h5mu",
+    "modality": "rna",
+    "slots": ["obsm", "varm"],
+    "output_compression": "gzip",
+}
+meta = {"resources_dir": "src/utils"}
+## VIASH END
+
+sys.path.append(meta["resources_dir"])
+from setup_logger import setup_logger
+
+
+logger = setup_logger()
+
+
+def main(par):
+    logger.info("clear_slots scaffold placeholder")
+
+
+if __name__ == "__main__":
+    sys.exit(main(par))

--- a/src/transform/clear_slots/test.py
+++ b/src/transform/clear_slots/test.py
@@ -1,0 +1,11 @@
+import sys
+
+import pytest
+
+
+def test_scaffold_exists():
+    assert True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/src/transform/clear_slots/test.py
+++ b/src/transform/clear_slots/test.py
@@ -1,10 +1,133 @@
 import sys
+from subprocess import CalledProcessError
 
+import mudata as mu
 import pytest
 
+from openpipeline_testutils.asserters import assert_annotation_objects_equal
 
-def test_scaffold_exists():
-    assert True
+
+## VIASH START
+meta = {
+    "resources_dir": "./resources_test/",
+}
+## VIASH END
+
+
+ts_blood_file = f"{meta['resources_dir']}/annotation_test_data/TS_Blood_filtered.h5mu"
+pbmc_file = (
+    f"{meta['resources_dir']}/pbmc_1k_protein_v3/"
+    "pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"
+)
+
+
+@pytest.mark.parametrize("output_compression", [None, "gzip", "lzf"])
+def test_clear_multiple_slots(run_component, random_h5mu_path, output_compression):
+    temp_output = random_h5mu_path()
+
+    arguments = [
+        "--input",
+        ts_blood_file,
+        "--modality",
+        "rna",
+        "--slots",
+        "obsm",
+        "--slots",
+        "varm",
+        "--output",
+        temp_output,
+    ]
+    if output_compression:
+        arguments.extend(["--output_compression", output_compression])
+
+    run_component(arguments)
+
+    output = mu.read_h5mu(temp_output)
+    assert len(output.mod["rna"].obsm) == 0
+    assert "log_normalized" in output.mod["rna"].layers
+    assert set(output.mod) == {"rna"}
+
+    expected = mu.read_h5mu(ts_blood_file)
+    expected.mod["rna"].obsm.clear()
+    assert_annotation_objects_equal(expected, output)
+
+
+@pytest.mark.parametrize(
+    ("slot", "source_file"),
+    [
+        ("varm", ts_blood_file),
+        ("obsp", ts_blood_file),
+        ("varp", ts_blood_file),
+        ("uns", pbmc_file),
+    ],
+)
+def test_clear_individual_supported_slots(
+    run_component, random_h5mu_path, slot, source_file
+):
+    temp_output = random_h5mu_path()
+    input_data = mu.read_h5mu(source_file)
+    before_len = len(getattr(input_data.mod["rna"], slot))
+
+    run_component(
+        [
+            "--input",
+            source_file,
+            "--modality",
+            "rna",
+            "--slots",
+            slot,
+            "--output",
+            temp_output,
+        ]
+    )
+
+    output = mu.read_h5mu(temp_output)
+    assert len(getattr(output.mod["rna"], slot)) == 0
+    assert before_len >= 0
+
+
+def test_multimodal_pbmc_preserves_untouched_modality(run_component, random_h5mu_path):
+    temp_output = random_h5mu_path()
+
+    run_component(
+        [
+            "--input",
+            pbmc_file,
+            "--modality",
+            "rna",
+            "--slots",
+            "uns",
+            "--output",
+            temp_output,
+        ]
+    )
+
+    output = mu.read_h5mu(temp_output)
+    expected = mu.read_h5mu(pbmc_file)
+    expected.mod["rna"].uns.clear()
+    assert set(output.mod) == {"rna", "prot"}
+    assert_annotation_objects_equal(expected, output)
+
+
+def test_missing_modality_raises(run_component, random_h5mu_path):
+    temp_output = random_h5mu_path()
+
+    with pytest.raises(CalledProcessError) as err:
+        run_component(
+            [
+                "--input",
+                pbmc_file,
+                "--modality",
+                "missing_modality",
+                "--slots",
+                "obsm",
+                "--output",
+                temp_output,
+            ]
+        )
+
+    assert not temp_output.is_file()
+    assert "modality" in err.value.stdout.decode("utf-8").lower()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changelog

Add a `clear_slots` component that can be used to remove all items from slots of a `MuData` object.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!