### PR TITLE
Add `cellmapper` outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 * `workflows/multiomics/process_singlesample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: add `--intersect_obs` option to remove observations that are not present in all processed modalities, so each modality shares the same set of cells (PR #1173).
 
-* `labels_transfer/cellmapper`: New component that transfers labels from a reference to a query with a shared embedding using CellMapper (PR #1169)
+* `labels_transfer/cellmapper`: New component that transfers labels from a reference to a query with a shared embedding using CellMapper (PR #1169, PR #1177)
 
 ## MAJOR CHANGES
 

--- a/src/labels_transfer/cellmapper/script.py
+++ b/src/labels_transfer/cellmapper/script.py
@@ -2,7 +2,6 @@ import sys
 
 import cellmapper
 import mudata as mu
-import numpy as np
 
 ## VIASH START
 par = {
@@ -96,30 +95,21 @@ def main(par):
 
     logger.info("Running CellMapper")
     mapper = cellmapper.CellMapper(query_adata, ref_adata)
-    mapper.map(
-        obs_keys=par["reference_obs_targets"],
-        use_rep=use_rep,
-        n_neighbors=par["n_neighbors"],
-        prediction_postfix="_pred",
-        kernel_method=par["kernel_method"],
-    )
+    mapper.compute_neighbors(use_rep=use_rep, n_neighbors=par["n_neighbors"])
+    mapper.compute_mapping_matrix(kernel_method=par["kernel_method"])
 
-    # Map CellMapper's prediction column names to the user-specified output column names
     for target, output_pred, output_prob in zip(
         par["reference_obs_targets"],
         par["output_obs_predictions"],
         par["output_obs_probability"],
     ):
-        default_pred_col = f"{target}_pred"
-        if default_pred_col in query_adata.obs and output_pred != default_pred_col:
-            query_adata.obs[output_pred] = query_adata.obs.pop(default_pred_col)
-
-        if output_pred not in query_adata.obs and default_pred_col in query_adata.obs:
-            query_adata.obs[output_pred] = query_adata.obs[default_pred_col]
-
-        if output_prob not in query_adata.obs:
-            # CellMapper does not expose per-label probabilities in the returned obs.
-            query_adata.obs[output_prob] = np.nan
+        mapper.map_obs(
+            key=target, prediction_postfix="_pred", confidence_postfix="_conf"
+        )
+        query_adata.obs.rename(
+            columns={f"{target}_pred": output_pred, f"{target}_conf": output_prob},
+            inplace=True,
+        )
 
     # Remove the temporary embedding
     query_adata.obsm.pop(use_rep, None)

--- a/src/labels_transfer/cellmapper/test.py
+++ b/src/labels_transfer/cellmapper/test.py
@@ -73,6 +73,7 @@ def test_cellmapper_defaults(run_component, prepared_data, random_h5mu_path):
     assert "cell_type_pred" in out.mod["rna"].obs
     assert out.mod["rna"].obs["cell_type_pred"].notna().all()
     assert "cell_type_probability" in out.mod["rna"].obs
+    assert out.mod["rna"].obs["cell_type_probability"].notna().all()
 
 
 @pytest.mark.parametrize("kernel", ["jaccard", "gauss"])


### PR DESCRIPTION
## Changelog

Improve the `cellmapper` component outputs:

- Use manual steps instead of combined `map()` method
- Simplify obs column mapping
- Add computed probabilities from `map_obs()`

## Issue ticket number and link
Closes #1176 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!