### PR TITLE
Set `.var` index names in `from_h5ad_to_h5mu`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@
 
 * `dataflow/split_h5mu`: pin scipy version to 1.16.3 to avoid regression that corrupts large sparse matrix indexing (PR #1153).
 
+* `convert/from_h5ad_h5mu`: store and reset var index names to avoid issues with a change in mudata (PR #1184).
+
 # openpipelines 4.0.4
 
 ## BUG FIXES

--- a/src/convert/from_h5ad_to_h5mu/script.py
+++ b/src/convert/from_h5ad_to_h5mu/script.py
@@ -29,12 +29,17 @@ data = {
 }
 
 logger.info("Converting to mudata")
+var_index_names = {key: adata.var.index.name for key, adata in data.items()}
 mudata = mu.MuData(data)
 
 try:
     mudata.var_names_make_unique()
 except (TypeError, ValueError):
     pass
+
+# Set var index names to avoid https://github.com/scverse/mudata/issues/146
+for key, name in var_index_names.items():
+    mudata.mod[key].var.index.name = name
 
 logger.info("Writing to %s.", par["output"])
 mudata.write_h5mu(par["output"], compression=par["output_compression"])


### PR DESCRIPTION
## Changelog

Store the `.var` index name in `from_h5ad_to_h5mu` and set it after running `.var_names_make_unique()` to avoid https://github.com/scverse/mudata/issues/146 causing tests to fail.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI tests succeed!