### PR TITLE
Fix parsing of strings as floats in cellranger multi to h5mu conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 
 * `convert/from_h5ad_h5mu`: store and reset var index names to avoid issues with a change in mudata (PR #1184).
 
+* `convert/from_cellranger_multi_to_h5mu`: fix `KeyError` when sample IDs are purely numeric strings (e.g. `"660418809813"`); pandas was coercing them to floats while reading the metrics summary, causing a mismatch with the per-sample directory names (PR #XXXX).
+
 # openpipelines 4.0.4
 
 ## BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 
 * `convert/from_h5ad_h5mu`: store and reset var index names to avoid issues with a change in mudata (PR #1184).
 
-* `convert/from_cellranger_multi_to_h5mu`: fix `KeyError` when sample IDs are purely numeric strings (e.g. `"660418809813"`); pandas was coercing them to floats while reading the metrics summary, causing a mismatch with the per-sample directory names (PR #XXXX).
+* `convert/from_cellranger_multi_to_h5mu`: in multiplexed experiments, parse sample IDs as strings when reading the metrics summary, so purely numeric sample IDs (e.g. `"660418809813"`) are no longer coerced to floats and continue to match the per-sample directory names (PR #1192).
 
 # openpipelines 4.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 
 * `convert/from_h5ad_h5mu`: store and reset var index names to avoid issues with a change in mudata (PR #1184).
 
-* `convert/from_cellranger_multi_to_h5mu`: in multiplexed experiments, parse sample IDs as strings when reading the metrics summary, so purely numeric sample IDs (e.g. `"660418809813"`) are no longer coerced to floats and continue to match the per-sample directory names (PR #1192).
+* `convert/from_cellranger_multi_to_h5mu`: fix `KeyError` in multiplexed experiments when sample IDs look like floating-point numbers (e.g. `"156573596.0"`); the metrics summary is now parsed with string dtype so sample IDs continue to match the per-sample directory names (PR #1192).
 
 # openpipelines 4.0.4
 

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -239,7 +239,11 @@ def process_counts(counts_folder: Path, multiplexing_info, metrics_files):
     if multiplexing_info:
         # Get the mapping between the barcode and the sample ID from one of the metrics files
         metrics_file = pd.read_csv(
-            list(metrics_files.values())[0], decimal=".", quotechar='"', thousands=","
+            list(metrics_files.values())[0],
+            decimal=".",
+            quotechar='"',
+            thousands=",",
+            dtype={"Group Name": str, "Metric Value": str},
         )
         sample_ids = metrics_file[metrics_file["Metric Name"] == "Sample ID"]
         barcode_sample_mapping = (

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -244,7 +244,7 @@ def process_counts(counts_folder: Path, multiplexing_info, metrics_files):
             quotechar='"',
             thousands=",",
             usecols=("Group Name", "Metric Value", "Metric Name"),
-            dtype=pd.StringDtype,
+            dtype=pd.StringDtype(),
         )
         sample_ids = metrics_file[metrics_file["Metric Name"] == "Sample ID"]
         barcode_sample_mapping = (

--- a/src/convert/from_cellranger_multi_to_h5mu/script.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/script.py
@@ -243,7 +243,8 @@ def process_counts(counts_folder: Path, multiplexing_info, metrics_files):
             decimal=".",
             quotechar='"',
             thousands=",",
-            dtype={"Group Name": str, "Metric Value": str},
+            usecols=("Group Name", "Metric Value", "Metric Name"),
+            dtype=pd.StringDtype,
         )
         sample_ids = metrics_file[metrics_file["Metric Name"] == "Sample ID"]
         barcode_sample_mapping = (

--- a/src/convert/from_cellranger_multi_to_h5mu/test.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/test.py
@@ -437,4 +437,4 @@ def test_numerical_sample_names(run_component, tmp_path, input_fixed_rna):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-k", "test_numerical_sample_names"]))
+    sys.exit(pytest.main([__file__]))

--- a/src/convert/from_cellranger_multi_to_h5mu/test.py
+++ b/src/convert/from_cellranger_multi_to_h5mu/test.py
@@ -1,8 +1,10 @@
 import sys
 import pytest
 import math
+import fileinput
 from mudata import read_h5mu
-from shutil import copytree
+from shutil import copytree, ignore_patterns
+from pathlib import Path
 import json
 
 ## VIASH START
@@ -372,5 +374,67 @@ def test_vdj_no_cells(run_component, tmp_path, input_no_vdj_cells):
     assert converted_data["vdj_t"].n_obs == 0
 
 
+def test_numerical_sample_names(run_component, tmp_path, input_fixed_rna):
+    """
+    Test purely numerical sample names. This tests the matching
+    between the metrics summary file and the name of the
+    per-sample directories when all sample names are numerical.
+    """
+    rename_samples = {
+        "Colorectal_BC3": "156573596.0",
+        "Liver_BC1": "576221069.1",
+        "Ovarian_BC2": "358367694.2",
+        "Pancreas_BC4": "550142661.3",
+    }
+    input_with_numerical_names = tmp_path / "input_numerical_sample_names"
+    copytree(
+        input_fixed_rna,
+        input_with_numerical_names,
+        ignore=ignore_patterns(*rename_samples.keys()),
+    )
+    for dir_source, dir_target in rename_samples.items():
+        copytree(
+            Path(input_fixed_rna) / "per_sample_outs" / dir_source,
+            input_with_numerical_names / "per_sample_outs" / dir_target,
+        )
+
+    summary_files = [
+        sample_dir / "metrics_summary.csv"
+        for sample_dir in (input_with_numerical_names / "per_sample_outs").iterdir()
+    ]
+    for line in fileinput.input(summary_files, inplace=True):
+        for old_name, new_name in rename_samples.items():
+            line = line.replace(old_name, new_name)
+        sys.stdout.write(line)
+
+    output_dir = tmp_path / "converted"
+    output_path_template = output_dir / "*.h5mu"
+    samples_csv = tmp_path / "samples.csv"
+
+    # run component
+    run_component(
+        [
+            "--input",
+            input_with_numerical_names,
+            "--output",
+            str(output_path_template),
+            "--output_compression",
+            "gzip",
+            "--sample_csv",
+            samples_csv,
+        ]
+    )
+    assert output_dir.is_dir()
+    # check output
+    samples = [item for item in output_dir.iterdir() if item.is_file()]
+    sample_names = {item.name.removesuffix(".h5mu") for item in samples}
+    assert sample_names == {
+        "156573596.0",
+        "576221069.1",
+        "358367694.2",
+        "550142661.3",
+    }
+
+
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))
+    sys.exit(pytest.main([__file__, "-k", "test_numerical_sample_names"]))


### PR DESCRIPTION
## Changelog

... Describe your changes ...

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!