### PR TITLE
Surface scrublet params in single sample processing workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 * `workflows/multiomics/process_singlesample`, `workflows/multiomics/process_samples` and `workflows/rna/rna_singlesample`: surfaced `--scrublet_score_threshold` argument to allow manually setting the doublet score threshold instead of relying on automatic detection (PR #1183).
 
+* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: surfaced additional scrublet pass-through arguments (`--scrublet_expected_doublet_rate`, `--scrublet_stdev_doublet_rate`, `--scrublet_n_neighbors`, `--scrublet_sim_doublet_ratio`, `--scrublet_min_counts`, `--scrublet_min_cells`, `--scrublet_min_gene_variability_percent`, `--scrublet_num_pca_components`, `--scrublet_distance_metric`, `--scrublet_allow_automatic_threshold_detection_fail`) to allow tuning doublet detection (PR #1183).
+
+* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: added the `--scrublet_do_subset` flag to optionally remove cells classified as doublets from the output. By default doublets are only annotated (in `.obs`), preserving the existing behavior (PR #1183).
+
 ## MINOR CHANGES
 
 * `qc/calculate_qc_metrics`: parametrize the names of the top-n-vars `.obs` output columns with the `--output_obs_top_n_vars` flag (PR #1182).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
 
 * `workflows/multiomics/process_singlesample`, `workflows/multiomics/process_samples` and `workflows/rna/rna_singlesample`: surfaced `--scrublet_score_threshold` argument to allow manually setting the doublet score threshold instead of relying on automatic detection (PR #1183).
 
-* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: surfaced additional scrublet pass-through arguments (`--scrublet_expected_doublet_rate`, `--scrublet_stdev_doublet_rate`, `--scrublet_n_neighbors`, `--scrublet_sim_doublet_ratio`, `--scrublet_min_counts`, `--scrublet_min_cells`, `--scrublet_min_gene_variability_percent`, `--scrublet_num_pca_components`, `--scrublet_distance_metric`, `--scrublet_allow_automatic_threshold_detection_fail`) to allow tuning doublet detection (PR #1183).
+* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: surfaced additional scrublet pass-through arguments (`--scrublet_expected_doublet_rate`, `--scrublet_stdev_doublet_rate`, `--scrublet_n_neighbors`, `--scrublet_sim_doublet_ratio`, `--scrublet_min_counts`, `--scrublet_min_cells`, `--scrublet_min_gene_variability_percent`, `--scrublet_num_pca_components`, `--scrublet_distance_metric`, `--scrublet_allow_automatic_threshold_detection_fail`) to allow tuning doublet detection (PR #1198).
 
-* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: added the `--scrublet_do_subset` flag to optionally remove cells classified as doublets from the output. By default doublets are only annotated (in `.obs`), preserving the existing behavior (PR #1183).
+* `workflows/rna/rna_singlesample`, `workflows/multiomics/process_singlesample`: added the `--scrublet_do_subset` flag to optionally remove cells classified as doublets from the output. By default doublets are only annotated (in `.obs`), preserving the existing behavior (PR #1198).
 
 ## MINOR CHANGES
 

--- a/src/filter/filter_with_scrublet/script.py
+++ b/src/filter/filter_with_scrublet/script.py
@@ -84,7 +84,7 @@ try:
     keep_cells = np.invert(predicted_doublets)
 except TypeError:
     # Scrublet might not throw an error and return None if it fails to detect doublets...
-    if par["scrublet_score_threshold"]:
+    if par["scrublet_score_threshold"] is not None:
         raise RuntimeError(
             "Scrublet could not detect doublets even with a manual threshold set."
         )

--- a/src/workflows/multiomics/process_singlesample/process_singlesample.yaml
+++ b/src/workflows/multiomics/process_singlesample/process_singlesample.yaml
@@ -98,6 +98,13 @@ argument_groups:
         type: boolean_true
         description: Skip the scrublet doublet detection step.
 
+      - name: "--scrublet_do_subset"
+        type: boolean_true
+        description: |
+          Remove cells classified as doublets by scrublet from the output. By default
+          doublets are only annotated (in .obs "filter_with_scrublet" and
+          "scrublet_doublet_score") and kept in the output.
+
       - name: "--scrublet_score_threshold"
         type: double
         required: false
@@ -107,6 +114,64 @@ argument_groups:
           Manual doublet score threshold passed to filter_with_scrublet. Cells with a
           doublet score above this value are classified as doublets. If not provided,
           the threshold is determined automatically by Scrublet.
+      - name: "--scrublet_expected_doublet_rate"
+        type: double
+        required: false
+        min: 0
+        max: 1
+        description: |
+          The estimated fraction of doublets as from the experimental setup.
+      - name: "--scrublet_stdev_doublet_rate"
+        type: double
+        required: false
+        min: 0
+        description: Uncertainty in the expected doublet rate.
+      - name: "--scrublet_n_neighbors"
+        type: integer
+        required: false
+        min: 0
+        description: |
+          Number of neighbors used to construct the KNN classifier of observed transcriptomes
+          and simulated doublets.
+      - name: "--scrublet_sim_doublet_ratio"
+        type: double
+        required: false
+        min: 0
+        description: |
+          Number of doublets to simulate relative to the number of observed transcriptomes.
+      - name: "--scrublet_min_counts"
+        type: integer
+        required: false
+        description: |
+          The number of minimal UMI counts per cell that have to be present for initial cell
+          detection during scrublet doublet detection.
+      - name: "--scrublet_min_cells"
+        type: integer
+        required: false
+        description: |
+          The number of cells in which UMIs for a gene were detected during scrublet
+          doublet detection.
+      - name: "--scrublet_min_gene_variability_percent"
+        type: double
+        required: false
+        description: |
+          Keep the most highly variable genes (in the top percentile) as measured by the
+          v-statistic, used for gene filtering prior to PCA during scrublet doublet detection.
+      - name: "--scrublet_num_pca_components"
+        type: integer
+        required: false
+        description: |
+          Number of principal components used during PCA dimensionality reduction in scrublet
+          doublet detection.
+      - name: "--scrublet_distance_metric"
+        type: string
+        required: false
+        description: The distance metric used for computing similarities during scrublet doublet detection.
+      - name: "--scrublet_allow_automatic_threshold_detection_fail"
+        type: boolean_true
+        description: |
+          When scrublet fails to automatically determine the doublet score threshold, allow the
+          pipeline to continue and set the output columns to NA.
 
   - name: "CITE-seq filtering options"
     arguments:

--- a/src/workflows/multiomics/process_singlesample/test.nf
+++ b/src/workflows/multiomics/process_singlesample/test.nf
@@ -135,6 +135,7 @@ workflow test_wf3 {
       add_id_make_observation_keys_unique: true,
       add_id_obs_output: "sample_id",
       scrublet_score_threshold: 0.1,
+      scrublet_do_subset: true,
       skip_qc_metrics: true,
       output: "pbmc_scrublet_threshold_test.h5mu"
     ]

--- a/src/workflows/multiomics/process_singlesample_base/main.nf
+++ b/src/workflows/multiomics/process_singlesample_base/main.nf
@@ -97,7 +97,18 @@ workflow run_wf {
         "ribosomal_gene_regex": "ribosomal_gene_regex",
         "layer": "rna_layer",
         "skip_scrublet_doublet_detection": "skip_scrublet_doublet_detection",
-        "scrublet_score_threshold": "scrublet_score_threshold"
+        "scrublet_do_subset": "scrublet_do_subset",
+        "scrublet_score_threshold": "scrublet_score_threshold",
+        "scrublet_expected_doublet_rate": "scrublet_expected_doublet_rate",
+        "scrublet_stdev_doublet_rate": "scrublet_stdev_doublet_rate",
+        "scrublet_n_neighbors": "scrublet_n_neighbors",
+        "scrublet_sim_doublet_ratio": "scrublet_sim_doublet_ratio",
+        "scrublet_min_counts": "scrublet_min_counts",
+        "scrublet_min_cells": "scrublet_min_cells",
+        "scrublet_min_gene_variability_percent": "scrublet_min_gene_variability_percent",
+        "scrublet_num_pca_components": "scrublet_num_pca_components",
+        "scrublet_distance_metric": "scrublet_distance_metric",
+        "scrublet_allow_automatic_threshold_detection_fail": "scrublet_allow_automatic_threshold_detection_fail"
       ],
       "prot": [
         "min_counts": "prot_min_counts",

--- a/src/workflows/rna/rna_singlesample/config.vsh.yaml
+++ b/src/workflows/rna/rna_singlesample/config.vsh.yaml
@@ -98,6 +98,13 @@ argument_groups:
         type: boolean_true
         description: Skip the scrublet doublet detection step.
 
+      - name: "--scrublet_do_subset"
+        type: boolean_true
+        description: |
+          Remove cells classified as doublets by scrublet from the output. By default
+          doublets are only annotated (in .obs "filter_with_scrublet" and
+          "scrublet_doublet_score") and kept in the output.
+
       - name: "--scrublet_score_threshold"
         type: double
         required: false
@@ -107,7 +114,67 @@ argument_groups:
           Manual doublet score threshold passed to filter_with_scrublet. Cells with a
           doublet score above this value are classified as doublets. If not provided,
           the threshold is determined automatically by Scrublet.
-  
+      - name: "--scrublet_expected_doublet_rate"
+        type: double
+        required: false
+        min: 0
+        max: 1
+        description: |
+          The estimated fraction of doublets as from the experimental setup, passed to
+          filter_with_scrublet. If not provided, the component default is used.
+      - name: "--scrublet_stdev_doublet_rate"
+        type: double
+        required: false
+        min: 0
+        description: Uncertainty in the expected doublet rate, passed to filter_with_scrublet.
+      - name: "--scrublet_n_neighbors"
+        type: integer
+        required: false
+        min: 0
+        description: |
+          Number of neighbors used to construct the KNN classifier of observed transcriptomes
+          and simulated doublets, passed to filter_with_scrublet.
+      - name: "--scrublet_sim_doublet_ratio"
+        type: double
+        required: false
+        min: 0
+        description: |
+          Number of doublets to simulate relative to the number of observed transcriptomes,
+          passed to filter_with_scrublet.
+      - name: "--scrublet_min_counts"
+        type: integer
+        required: false
+        description: |
+          The number of minimal UMI counts per cell that have to be present for initial cell
+          detection during scrublet doublet detection.
+      - name: "--scrublet_min_cells"
+        type: integer
+        required: false
+        description: |
+          The number of cells in which UMIs for a gene were detected, used during scrublet
+          doublet detection.
+      - name: "--scrublet_min_gene_variability_percent"
+        type: double
+        required: false
+        description: |
+          Keep the most highly variable genes (in the top percentile) as measured by the
+          v-statistic, used for gene filtering prior to PCA during scrublet doublet detection.
+      - name: "--scrublet_num_pca_components"
+        type: integer
+        required: false
+        description: |
+          Number of principal components used during PCA dimensionality reduction in scrublet
+          doublet detection.
+      - name: "--scrublet_distance_metric"
+        type: string
+        required: false
+        description: The distance metric used for computing similarities during scrublet doublet detection.
+      - name: "--scrublet_allow_automatic_threshold_detection_fail"
+        type: boolean_true
+        description: |
+          When scrublet fails to automatically determine the doublet score threshold, allow the
+          pipeline to continue and set the output columns to NA.
+
   - name: "Mitochondrial & Ribosomal Gene Detection"
     arguments:
       - name: "--var_gene_names"

--- a/src/workflows/rna/rna_singlesample/main.nf
+++ b/src/workflows/rna/rna_singlesample/main.nf
@@ -174,7 +174,18 @@ workflow run_wf {
       fromState: [
         "input": "input",
         "layer": "layer",
+        "do_subset": "scrublet_do_subset",
         "scrublet_score_threshold": "scrublet_score_threshold",
+        "expected_doublet_rate": "scrublet_expected_doublet_rate",
+        "stdev_doublet_rate": "scrublet_stdev_doublet_rate",
+        "n_neighbors": "scrublet_n_neighbors",
+        "sim_doublet_ratio": "scrublet_sim_doublet_ratio",
+        "min_counts": "scrublet_min_counts",
+        "min_cells": "scrublet_min_cells",
+        "min_gene_variablity_percent": "scrublet_min_gene_variability_percent",
+        "num_pca_components": "scrublet_num_pca_components",
+        "distance_metric": "scrublet_distance_metric",
+        "allow_automatic_threshold_detection_fail": "scrublet_allow_automatic_threshold_detection_fail",
         "output": "workflow_output"
       ],
       args: [output_compression: "gzip"],

--- a/src/workflows/rna/rna_singlesample/test.nf
+++ b/src/workflows/rna/rna_singlesample/test.nf
@@ -59,6 +59,21 @@ workflow test_wf {
         min_cells_per_gene: 2,
         scrublet_score_threshold: 0.1,
         output: "scrublet_threshold_test.final.h5mu"
+      ],
+      [
+        id: "scrublet_parameters_test",
+        input: resources_test.resolve("pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"),
+        min_counts: 3,
+        max_counts: 10000000,
+        min_genes_per_cell: 2,
+        max_genes_per_cell: 10000000,
+        min_cells_per_gene: 2,
+        scrublet_expected_doublet_rate: 0.12,
+        scrublet_min_counts: 2,
+        scrublet_min_cells: 3,
+        scrublet_min_gene_variability_percent: 85,
+        scrublet_num_pca_components: 30,
+        output: "scrublet_parameters_test.final.h5mu"
       ]
     ])
     | map{ state -> [state.id, state] }
@@ -70,10 +85,10 @@ workflow test_wf {
     }
     | toSortedList{a, b -> a[0] <=> b[0]}
     | map { output_list ->
-      assert output_list.size() == 4 : "output channel should contain four events"
+      assert output_list.size() == 5 : "output channel should contain five events"
       println "output_list: $output_list"
-      assert output_list.collect{it[0]} == ["mitochondrial_ribosomal_test", "scrublet_threshold_test", "simple_execution_test", "skip_scrublet_test"] : "Output ID should be same as input ID"
-      assert (output_list.collect({it[1].output.getFileName().toString()}) as Set).equals(["mitochondrial_ribosomal_test.final.h5mu", "simple_execution_test.final.h5mu", "skip_scrublet_test.final.h5mu", "scrublet_threshold_test.final.h5mu"] as Set)
+      assert output_list.collect{it[0]} == ["mitochondrial_ribosomal_test", "scrublet_parameters_test", "scrublet_threshold_test", "simple_execution_test", "skip_scrublet_test"] : "Output ID should be same as input ID"
+      assert (output_list.collect({it[1].output.getFileName().toString()}) as Set).equals(["mitochondrial_ribosomal_test.final.h5mu", "scrublet_parameters_test.final.h5mu", "simple_execution_test.final.h5mu", "skip_scrublet_test.final.h5mu", "scrublet_threshold_test.final.h5mu"] as Set)
 
     }
 }

--- a/src/workflows/test_workflows/multiomics/process_samples/assert_test_workflow_2_output/script.py
+++ b/src/workflows/test_workflows/multiomics/process_samples/assert_test_workflow_2_output/script.py
@@ -189,8 +189,6 @@ def test_rna_obs_slots(output_h5mu):
 
     other_columns = [
         "sample_id",
-        "scrublet_doublet_score",
-        "filter_with_scrublet",
         "filter_with_counts",
         "num_nonzero_vars",
         "total_counts",

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow2_test/script.py
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow2_test/script.py
@@ -28,7 +28,6 @@ expected_rna_obs_keys = [
     "filter_mitochondrial",
     "filter_ribosomal",
     "filter_with_counts",
-    "filter_with_scrublet",
 ]
 expected_rna_var_keys = ["mitochondrial", "ribosomal", "filter_with_counts"]
 assert all(key in list(output.mod["rna"].obs) for key in expected_rna_obs_keys), (

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow3_test/config.vsh.yaml
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow3_test/config.vsh.yaml
@@ -1,7 +1,7 @@
 name: "workflow3_test"
 namespace: "test_workflows/multiomics/process_singlesample"
 scope: "test"
-description: "This component tests the output of the integration test of process_singlesample test_wf3, which exercises the --scrublet_score_threshold parameter."
+description: "This component tests the output of the integration test of process_singlesample test_wf3, which verifies that cells classified as doublets (scrublet score above --scrublet_score_threshold) are removed from the output."
 authors:
   - __merge__: /src/authors/dorien_roosen.yaml
 argument_groups:

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow3_test/script.py
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow3_test/script.py
@@ -32,8 +32,9 @@ assert "filter_with_scrublet" in rna_obs.columns, (
 )
 
 # The manual threshold means: cells with doublet score > threshold are
-# classified as doublets (filter_with_scrublet == False), the rest are kept
-# (filter_with_scrublet == True).
+# classified as doublets and are removed by the do_filter step that follows
+# scrublet. Every cell remaining in the output must therefore be a non-doublet
+# (scrublet_doublet_score <= threshold, filter_with_scrublet == True).
 threshold = par["scrublet_score_threshold"]
 doublet_scores = rna_obs["scrublet_doublet_score"].to_numpy(dtype=float)
 keep_cells = rna_obs["filter_with_scrublet"].to_numpy(dtype=bool)
@@ -43,16 +44,21 @@ assert not np.isnan(doublet_scores).all(), (
 )
 
 valid = ~np.isnan(doublet_scores)
-expected_keep = doublet_scores[valid] <= threshold
-actual_keep = keep_cells[valid]
-assert np.array_equal(actual_keep, expected_keep), (
-    f"filter_with_scrublet should match (scrublet_doublet_score <= {threshold}). "
-    f"Mismatches: {(actual_keep != expected_keep).sum()} out of {valid.sum()} cells."
+assert (doublet_scores[valid] <= threshold).all(), (
+    f"Cells with a doublet score above the manual threshold of {threshold} should "
+    f"have been removed, but {(doublet_scores[valid] > threshold).sum()} remain in "
+    f"the output."
+)
+assert keep_cells[valid].all(), (
+    "All cells remaining after filtering should be tagged as kept "
+    "(filter_with_scrublet == True)."
 )
 
-assert (doublet_scores[valid] > threshold).any(), (
-    f"Expected at least one cell with doublet score above the manual threshold "
-    f"of {threshold} to confirm the threshold was applied."
+# Confirm that doublet removal actually reduced the number of RNA observations
+# relative to the unfiltered input.
+assert output.mod["rna"].n_obs < input.mod["rna"].n_obs, (
+    f"Expected doublet removal to reduce the number of RNA observations below the "
+    f"input ({input.mod['rna'].n_obs}), but got {output.mod['rna'].n_obs}."
 )
 
 print("Test successful!", flush=True)

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow_test/script.py
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow_test/script.py
@@ -23,8 +23,6 @@ assert input.shape == output.shape, (
 
 expected_rna_obs_keys = [
     "filter_with_counts",
-    "scrublet_doublet_score",
-    "filter_with_scrublet",
 ]
 
 # Check rna modality


### PR DESCRIPTION
## Changelog
 ### 📚 Stacked PR (2 of 3) — review/merge bottom-up

 - #1199 — add qc metric calculation — base: `main`
 - 👉 **#1198 — Surface scrublet params** _(this PR)_ — base: `qc-metrics-process-singlesample`
 - #1200 — Add quantile filtering — base: `extend-scrublet-params`

Stacked on **#1199** — this PR's diff is shown against `qc-metrics-process-singlesample`, so you only see the scrublet changes. Please review/merge **#1199 first**.
**Merge order: #1199 → 👉 #1198 → #1200.**


## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!