### PR TITLE
add qc metric calculation to single sample workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * `workflows/qc/qc`, `workflows/rna/rna_multisample`, `workflows/prot/prot_multisample`, `workflows/multiomics/process_samples` and `workflows/multiomics/process_batches`: expose the `--log1p_transform` flag (PR #1182).
 
+* `workflows/multiomics/process_singlesample`: now calculates basic QC metrics for the RNA and protein modalities by default, adding metric columns to `.obs` and `.var` of the output. This can be disabled with the new `--skip_qc_metrics` flag (PR #1148).
+
 ## NEW FEATURES
 
 * `filter/filter_with_scrublet`: added `--scrublet_score_threshold` argument to allow manually setting the doublet score threshold instead of relying on automatic detection (PR #1183).
@@ -33,7 +35,7 @@
 * `workflows/rna/rna_multisample`, `workflows/multiomics/process_batches`, `feature_annotation/highly_variable_features_scanpy`: add an option to exclude features before running highly variable gene calculation based on a user-defined list of feature names (PR #1121).
 
 * `annotate/consensus_vote`: new component computing a (weighted) majority vote across cell type labels from multiple annotation methods (PR #1151).
-* 
+
 * `filter/filter_with_quantile`: added a component to filter numerical .obs or .var columns based on quantile thresholds, with optional subsetting (PR #1146).
 
 * `dimred/pca`: added possibility to do chunked processing using arguments `chunks` and `chunk_size`. Also added a `seed` argument in order to better control the variability between executions (PR #1157).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * `workflows/qc/qc`, `workflows/rna/rna_multisample`, `workflows/prot/prot_multisample`, `workflows/multiomics/process_samples` and `workflows/multiomics/process_batches`: expose the `--log1p_transform` flag (PR #1182).
 
-* `workflows/multiomics/process_singlesample`: now calculates basic QC metrics for the RNA and protein modalities by default, adding metric columns to `.obs` and `.var` of the output. This can be disabled with the new `--skip_qc_metrics` flag (PR #1148).
+* `workflows/multiomics/process_singlesample`: now calculates basic QC metrics for the RNA and protein modalities by default, adding metric columns to `.obs` and `.var` of the output. This can be disabled with the new `--skip_qc_metrics` flag (PR #1199).
 
 ## NEW FEATURES
 

--- a/src/workflows/multiomics/process_singlesample/config.vsh.yaml
+++ b/src/workflows/multiomics/process_singlesample/config.vsh.yaml
@@ -10,15 +10,112 @@ info:
       namespace: test_workflows/multiomics/process_singlesample
     - name: workflow3_test
       namespace: test_workflows/multiomics/process_singlesample
+    - name: workflow4_test
+      namespace: test_workflows/multiomics/process_singlesample
 authors:
   - __merge__: /src/authors/dorien_roosen.yaml
     roles: [ author ]
 __merge__: process_singlesample.yaml
 
+argument_groups:
+  - name: "Cross-modality filtering"
+    arguments:
+      - name: "--intersect_obs"
+        type: boolean_true
+        description: |
+          After per-modality filtering, remove observations that are not present
+          in all processed modalities so that each modality shares the same set of cells.
+
+  - name: "QC metrics calculation options"
+    description: |
+      Options for calculating basic quality control metrics on the processed
+      RNA and protein modalities. These metrics are added to the .obs and .var
+      of the output. Mitochondrial and ribosomal genes used for the metrics are
+      detected during single-sample processing (see the options above).
+    arguments:
+      - name: "--skip_qc_metrics"
+        type: boolean_true
+        description: |
+          Skip the calculation of QC metrics. By default, QC metrics are
+          calculated for the RNA and protein modalities.
+      - name: "--var_qc_metrics"
+        description: |
+          Keys to select a boolean (containing only True or False) column from .var.
+          For each cell, calculate the proportion of total values for genes which are labeled 'True',
+          compared to the total sum of the values for all genes. Defaults to the columns specified by
+          --var_name_mitochondrial_genes and --var_name_ribosomal_genes (RNA modality only).
+        type: string
+        multiple: True
+        multiple_sep: ','
+        required: false
+        example: "ercc,highly_variable"
+      - name: "--top_n_vars"
+        type: integer
+        description: |
+          Number of top vars to be used to calculate cumulative proportions.
+          If not specified, proportions are not calculated. `--top_n_vars 20,50` finds
+          cumulative proportion to the 20th and 50th most expressed vars.
+        multiple: true
+        multiple_sep: ','
+        required: false
+        default: [50, 100, 200, 500]
+      - name: "--log1p_transform"
+        description: |
+          Compute log1p-transformed versions of the calculated QC metrics. For each emitted
+          metric column `<col>`, an additional column `log1p_<col>` is added containing
+          `log1p(<col>)`. Mirrors scanpy's `log1p` flag.
+        type: boolean
+        default: true
+        required: false
+      - name: "--output_obs_num_nonzero_vars"
+        description: |
+          Name of column in .obs describing, for each observation, the number of stored values
+          (including explicit zeroes). In other words, the name of the column that counts
+          for each row the number of columns that contain data.
+        type: string
+        required: false
+        default: "num_nonzero_vars"
+      - name: "--output_obs_total_counts_vars"
+        description: |
+          Name of the column for .obs describing, for each observation (row),
+          the sum of the stored values in the columns.
+        type: string
+        required: false
+        default: total_counts
+      - name: "--output_var_num_nonzero_obs"
+        description: |
+          Name of column describing, for each feature, the number of stored values
+          (including explicit zeroes). In other words, the name of the column that counts
+          for each column the number of rows that contain data.
+        type: string
+        required: false
+        default: "num_nonzero_obs"
+      - name: "--output_var_total_counts_obs"
+        description: |
+          Name of the column in .var describing, for each feature (column),
+          the sum of the stored values in the rows.
+        type: string
+        required: false
+        default: total_counts
+      - name: "--output_var_obs_mean"
+        type: string
+        description: |
+          Name of the column in .obs providing the mean of the values in each row.
+        default: "obs_mean"
+        required: false
+      - name: "--output_var_pct_dropout"
+        type: string
+        default: "pct_dropout"
+        description: |
+          Name of the column in .obs providing for each feature the percentage of
+          observations the feature does not appear on (i.e. is missing). Same as `--output_var_num_nonzero_obs`
+          but percentage based.
+
 dependencies:
   - name: dataflow/merge
   - name: filter/intersect_obs
   - name: workflows/multiomics/process_singlesample_base
+  - name: qc/calculate_qc_metrics
 
 resources:
   - type: nextflow_script
@@ -37,6 +134,9 @@ test_resources:
   - type: nextflow_script
     path: test.nf
     entrypoint: test_wf3
+  - type: nextflow_script
+    path: test.nf
+    entrypoint: test_wf4
   - path: /resources_test/concat_test_data
   - path: /resources_test/pbmc_1k_protein_v3
 runners:

--- a/src/workflows/multiomics/process_singlesample/main.nf
+++ b/src/workflows/multiomics/process_singlesample/main.nf
@@ -3,6 +3,24 @@ workflow run_wf {
     input_ch
 
   main:
+
+    // QC metrics are only calculated for the modalities listed here. Each entry
+    // maps a modality to:
+    //   - layer: the state key holding that modality's input layer.
+    //   - var_qc_metrics_keys: state keys pointing to boolean .var columns
+    //     (detected during single-sample processing) for which per-cell
+    //     proportions are calculated. Empty for modalities without such columns.
+    def qc_metrics_modalities = [
+      "rna": [
+        "layer": "rna_layer",
+        "var_qc_metrics_keys": ["var_name_mitochondrial_genes", "var_name_ribosomal_genes"],
+      ],
+      "prot": [
+        "layer": "prot_layer",
+        "var_qc_metrics_keys": [],
+      ],
+    ].asImmutable()
+
     output_ch = input_ch
       // Make sure there is not conflict between the output from this workflow
       // And the output from any of the components
@@ -17,6 +35,51 @@ workflow run_wf {
           "modality": "output_modality"
         ]
       )
+      // Calculate basic QC metrics for the relevant modalities (see
+      // qc_metrics_modalities above). Mitochondrial and ribosomal genes were
+      // already detected during single-sample processing, so they can be used
+      // directly here.
+      // Runs per modality before the modalities are merged back together.
+      // process_singlesample_base assigns the same id to every modality of a
+      // sample, so make the id unique per modality to let the qc component run
+      // per modality. The original id is kept in _meta.join_id to restore it
+      // before grouping the modalities back together.
+      | map {id, state -> ["${id}_${state.modality}", state + ["_meta": ["join_id": id]]]}
+      | calculate_qc_metrics.run(
+        runIf: {id, state -> !state.skip_qc_metrics && qc_metrics_modalities.containsKey(state.modality)},
+        fromState: {id, state ->
+          def modality_config = qc_metrics_modalities[state.modality]
+          // For modalities with boolean .var columns, a user-provided
+          // --var_qc_metrics takes precedence; otherwise the configured columns
+          // (e.g. mitochondrial/ribosomal for rna) are used when present.
+          def var_qc_metrics = null
+          if (modality_config.var_qc_metrics_keys) {
+            def detected_var_qc_metrics = modality_config.var_qc_metrics_keys.collect{state[it]}.findAll{it != null}
+            var_qc_metrics = state.var_qc_metrics ?: detected_var_qc_metrics
+          }
+          def newState = [
+            "input": state.input,
+            "modality": state.modality,
+            "layer": state[modality_config.layer],
+            "top_n_vars": state.top_n_vars,
+            "log1p_transform": state.log1p_transform,
+            "output_obs_num_nonzero_vars": state.output_obs_num_nonzero_vars,
+            "output_obs_total_counts_vars": state.output_obs_total_counts_vars,
+            "output_var_num_nonzero_obs": state.output_var_num_nonzero_obs,
+            "output_var_total_counts_obs": state.output_var_total_counts_obs,
+            "output_var_obs_mean": state.output_var_obs_mean,
+            "output_var_pct_dropout": state.output_var_pct_dropout,
+            "output_compression": "gzip"
+          ]
+          if (var_qc_metrics) {
+            newState += ["var_qc_metrics": var_qc_metrics]
+          }
+          return newState
+        },
+        toState: ["input": "output"]
+      )
+      // Restore the original sample id so the modalities group back together.
+      | map {id, state -> [state._meta.join_id, state]}
       | groupTuple(by: 0, sort: "hash")
       | map { id, states ->
           def new_input = states.collect{it.input}
@@ -43,16 +106,15 @@ workflow run_wf {
           "input": "input",
           "output": "workflow_output"
         ],
-        toState: {id, output, state -> 
-          ["output": output.output]
-        }
+        toState: ["output": "output"]
       )
       | view {"After smerging: $it"}
       | intersect_obs.run(
         runIf: {id, state -> state.intersect_obs},
         fromState:[
           "input": "output",
-          "modalities": "modalities"
+          "modalities": "modalities",
+          "output": "workflow_output"
         ],
         toState: {id, output, state -> 
           ["output": output.output]

--- a/src/workflows/multiomics/process_singlesample/process_singlesample.yaml
+++ b/src/workflows/multiomics/process_singlesample/process_singlesample.yaml
@@ -154,16 +154,7 @@ argument_groups:
       - name: "--gdo_min_cells_per_guide"
         example: 3
         type: integer
-        description: Minimum of non-zero values per guide. 
-    
-  
-  - name: "Cross-modality filtering"
-    arguments:
-      - name: "--intersect_obs"
-        type: boolean_true
-        description: |
-          After per-modality filtering, remove observations that are not present
-          in all processed modalities so that each modality shares the same set of cells.
+        description: Minimum of non-zero values per guide.
 
   - name: "Mitochondrial & Ribosomal Gene Detection"
     arguments:

--- a/src/workflows/multiomics/process_singlesample/test.nf
+++ b/src/workflows/multiomics/process_singlesample/test.nf
@@ -5,6 +5,7 @@ include { process_singlesample } from targetDir + "/nextflow/workflows/multiomic
 include { workflow_test } from targetDir + "/_test/nextflow/test_workflows/multiomics/process_singlesample/workflow_test/main.nf"
 include { workflow2_test } from targetDir + "/_test/nextflow/test_workflows/multiomics/process_singlesample/workflow2_test/main.nf"
 include { workflow3_test } from targetDir + "/_test/nextflow/test_workflows/multiomics/process_singlesample/workflow3_test/main.nf"
+include { workflow4_test } from targetDir + "/_test/nextflow/test_workflows/multiomics/process_singlesample/workflow4_test/main.nf"
 
 params.resources_test = params.rootDir + "/resources_test"
 
@@ -82,6 +83,7 @@ workflow test_wf2 {
       do_subset: true,
       add_id_obs_output: "sample_id",
       intersect_obs: true,
+      skip_qc_metrics: true,
       output: "pbmc_test.h5mu"
     ]
   ])
@@ -133,6 +135,7 @@ workflow test_wf3 {
       add_id_make_observation_keys_unique: true,
       add_id_obs_output: "sample_id",
       scrublet_score_threshold: 0.1,
+      skip_qc_metrics: true,
       output: "pbmc_scrublet_threshold_test.h5mu"
     ]
   ])
@@ -160,5 +163,101 @@ workflow test_wf3 {
         "orig_input": "orig_input",
         "scrublet_score_threshold": "scrublet_score_threshold"
       ],
+    )
+}
+
+workflow test_wf4 {
+
+  resources_test = file(params.resources_test)
+
+  // Shared single-sample processing parameters. QC metrics are calculated
+  def base_args = [
+    input: resources_test.resolve("pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix.h5mu"),
+    rna_min_counts: 2,
+    rna_max_counts: 1000000,
+    rna_min_genes_per_cell: 1,
+    rna_max_genes_per_cell: 1000000,
+    rna_min_cells_per_gene: 1,
+    rna_min_fraction_mito: 0.0,
+    rna_max_fraction_mito: 1.0,
+    prot_min_counts: 3,
+    prot_max_counts: 1000000,
+    prot_min_proteins_per_cell: 1,
+    prot_max_proteins_per_cell: 1000000,
+    prot_min_cells_per_protein: 1,
+    var_name_mitochondrial_genes: 'mitochondrial',
+    obs_name_mitochondrial_fraction: 'fraction_mitochondrial',
+    var_name_ribosomal_genes: 'ribosomal',
+    obs_name_ribosomal_fraction: 'fraction_ribosomal',
+    add_id_to_obs: true,
+    add_id_make_observation_keys_unique: true,
+    add_id_obs_output: "sample_id",
+    intersect_obs: true
+  ]
+
+  input_ch = Channel.fromList([
+    // Default output slots: QC metric columns use the default names.
+    base_args + [
+      id: "pbmc_default_slots",
+      output: "pbmc_default_slots.h5mu"
+    ],
+    // Non-default output slots: QC metric columns use custom names and a
+    // non-default set of top_n_vars. The renamed-away default names must not
+    // appear in the output (verified by the test component).
+    base_args + [
+      id: "pbmc_custom_slots",
+      output: "pbmc_custom_slots.h5mu",
+      output_obs_num_nonzero_vars: "custom_num_nonzero_vars",
+      output_obs_total_counts_vars: "custom_obs_total_counts",
+      output_var_num_nonzero_obs: "custom_num_nonzero_obs",
+      output_var_total_counts_obs: "custom_var_total_counts",
+      output_var_obs_mean: "custom_obs_mean",
+      output_var_pct_dropout: "custom_pct_dropout",
+      top_n_vars: [10, 20]
+    ]
+  ])
+  | map{ state -> [state.id, state] }
+  | process_singlesample.run(
+    toState: { id, output, state -> state + output + [orig_input: state.input] }
+  )
+
+  assert_ch = input_ch
+  | view { output ->
+    assert output.size() == 2 : "outputs should contain two elements; [id, file]"
+    "Output: $output"
+  }
+  | toSortedList()
+  | map { output_list ->
+    assert output_list.size() == 2 : "output channel should contain two events, got ${output_list.size()}"
+    assert output_list.collect{it[0]}.sort() == ["pbmc_custom_slots", "pbmc_default_slots"] : "Output ids should be `pbmc_custom_slots` and `pbmc_default_slots`."
+  }
+
+  test_ch = input_ch
+    | workflow4_test.run(
+      // Only pass slot arguments that were explicitly set on the event. Passing
+      // a null would override the test component's default (which mirrors the
+      // process_singlesample default), so unset arguments are omitted instead.
+      fromState: { id, state ->
+        def args = [
+          "input": state.output,
+          "orig_input": state.orig_input
+        ]
+        def passthrough = [
+          "output_obs_num_nonzero_vars",
+          "output_obs_total_counts_vars",
+          "output_var_num_nonzero_obs",
+          "output_var_total_counts_obs",
+          "output_var_obs_mean",
+          "output_var_pct_dropout",
+          "log1p_transform",
+          "top_n_vars",
+          "var_name_mitochondrial_genes",
+          "var_name_ribosomal_genes"
+        ]
+        passthrough.each { key ->
+          if (state[key] != null) { args[key] = state[key] }
+        }
+        return args
+      }
     )
 }

--- a/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
+++ b/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
@@ -43,6 +43,7 @@ del output_prot.obs["log1p_num_nonzero_vars"]
 del output_prot.obs["log1p_total_counts"]
 del output_prot.var["log1p_obs_mean"]
 del output_prot.var["log1p_total_counts"]
+del output_prot.var["pct_dropout"]
 assert_annotation_objects_equal(input_prot, output_prot, promote_precision=True)
 
 

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow4_test/config.vsh.yaml
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow4_test/config.vsh.yaml
@@ -1,0 +1,69 @@
+name: "workflow4_test"
+namespace: "test_workflows/multiomics/process_singlesample"
+scope: "test"
+description: "This component tests the output of the integration test of process_singlesample test_wf4, which verifies that QC metrics are calculated correctly with both default and non-default output slot names."
+authors:
+  - __merge__: /src/authors/dorien_roosen.yaml
+argument_groups:
+  - name: Inputs
+    arguments:
+      - name: "--input"
+        type: file
+        required: true
+        description: Path to the processed h5mu file.
+        example: test.h5mu
+      - name: "--orig_input"
+        type: file
+        required: true
+        description: Path to the original input file.
+        example: input.h5mu
+  - name: QC metric slots
+    description: |
+      Names of the QC metric output columns to verify. Defaults match the
+      process_singlesample defaults so the same component can verify both the
+      default-slot and non-default-slot runs. When a slot is renamed, the script
+      additionally asserts that the corresponding default-named column is absent.
+    arguments:
+      - name: "--output_obs_num_nonzero_vars"
+        type: string
+        default: "num_nonzero_vars"
+      - name: "--output_obs_total_counts_vars"
+        type: string
+        default: "total_counts"
+      - name: "--output_var_num_nonzero_obs"
+        type: string
+        default: "num_nonzero_obs"
+      - name: "--output_var_total_counts_obs"
+        type: string
+        default: "total_counts"
+      - name: "--output_var_obs_mean"
+        type: string
+        default: "obs_mean"
+      - name: "--output_var_pct_dropout"
+        type: string
+        default: "pct_dropout"
+      - name: "--top_n_vars"
+        type: integer
+        multiple: true
+        default: [50, 100, 200, 500]
+      - name: "--log1p_transform"
+        type: boolean
+        default: true
+      - name: "--var_name_mitochondrial_genes"
+        type: string
+        default: "mitochondrial"
+      - name: "--var_name_ribosomal_genes"
+        type: string
+        default: "ribosomal"
+resources:
+  - type: python_script
+    path: script.py
+engines:
+  - type: docker
+    image: python:3.13-slim
+    __merge__: /src/base/requirements/testworkflows_setup.yaml
+runners:
+  - type: executable
+  - type: nextflow
+    directives:
+      label: ["midmem"]

--- a/src/workflows/test_workflows/multiomics/process_singlesample/workflow4_test/script.py
+++ b/src/workflows/test_workflows/multiomics/process_singlesample/workflow4_test/script.py
@@ -1,0 +1,142 @@
+import mudata as mu
+
+##VIASH START
+par = {
+    "input": "output.h5mu",
+    "orig_input": "input.h5mu",
+    "output_obs_num_nonzero_vars": "num_nonzero_vars",
+    "output_obs_total_counts_vars": "total_counts",
+    "output_var_num_nonzero_obs": "num_nonzero_obs",
+    "output_var_total_counts_obs": "total_counts",
+    "output_var_obs_mean": "obs_mean",
+    "output_var_pct_dropout": "pct_dropout",
+    "top_n_vars": [50, 100, 200, 500],
+    "log1p_transform": True,
+    "var_name_mitochondrial_genes": "mitochondrial",
+    "var_name_ribosomal_genes": "ribosomal",
+}
+
+meta = {"resources_dir": "resources_test/pbmc_1k_protein_v3"}
+
+##VIASH END
+
+# Default slot names and top_n_vars, matching the process_singlesample defaults.
+# These are the names that must NOT appear once a slot has been renamed.
+DEFAULT_OBS_TOTAL_COUNTS = "total_counts"
+DEFAULT_OBS_NUM_NONZERO = "num_nonzero_vars"
+DEFAULT_VAR_OBS_MEAN = "obs_mean"
+DEFAULT_VAR_TOTAL_COUNTS = "total_counts"
+DEFAULT_VAR_NUM_NONZERO = "num_nonzero_obs"
+DEFAULT_VAR_PCT_DROPOUT = "pct_dropout"
+DEFAULT_TOP_N_VARS = [50, 100, 200, 500]
+
+log1p = par["log1p_transform"]
+
+
+def top_n_column(n):
+    return f"pct_of_counts_in_top_{n}_vars"
+
+
+print("Loading data", flush=True)
+input = mu.read_h5mu(par["orig_input"])
+output = mu.read_h5mu(par["input"])
+
+assert input.n_mod == output.n_mod, "Number of modalities differ"
+assert input.mod.keys() == output.mod.keys(), "Modalities differ"
+expected_mod = ["prot", "rna"]
+assert all(key in list(output.mod.keys()) for key in expected_mod), (
+    f"Expected modalities {expected_mod}, found: {list(output.mod.keys())}."
+)
+
+# QC metric columns calculated for every processed modality.
+common_obs_present = [
+    par["output_obs_num_nonzero_vars"],
+    par["output_obs_total_counts_vars"],
+]
+common_obs_present += [top_n_column(n) for n in par["top_n_vars"]]
+if log1p:
+    common_obs_present += [
+        f"log1p_{par['output_obs_num_nonzero_vars']}",
+        f"log1p_{par['output_obs_total_counts_vars']}",
+    ]
+
+common_var_present = [
+    par["output_var_obs_mean"],
+    par["output_var_total_counts_obs"],
+    par["output_var_num_nonzero_obs"],
+    par["output_var_pct_dropout"],
+]
+if log1p:
+    common_var_present += [
+        f"log1p_{par['output_var_obs_mean']}",
+        f"log1p_{par['output_var_total_counts_obs']}",
+    ]
+
+# Per-cell proportions for boolean .var columns are only calculated for the rna
+# modality (mitochondrial and ribosomal genes). These column names are fixed and
+# not affected by the output slot arguments.
+rna_obs_present = list(common_obs_present)
+for metric in [par["var_name_mitochondrial_genes"], par["var_name_ribosomal_genes"]]:
+    rna_obs_present += [f"total_counts_{metric}", f"pct_{metric}"]
+    if log1p:
+        rna_obs_present.append(f"log1p_total_counts_{metric}")
+
+# Default-named columns that must be absent when the corresponding slot is renamed.
+absent_obs = []
+if par["output_obs_num_nonzero_vars"] != DEFAULT_OBS_NUM_NONZERO:
+    absent_obs.append(DEFAULT_OBS_NUM_NONZERO)
+    if log1p:
+        absent_obs.append(f"log1p_{DEFAULT_OBS_NUM_NONZERO}")
+if par["output_obs_total_counts_vars"] != DEFAULT_OBS_TOTAL_COUNTS:
+    absent_obs.append(DEFAULT_OBS_TOTAL_COUNTS)
+    if log1p:
+        absent_obs.append(f"log1p_{DEFAULT_OBS_TOTAL_COUNTS}")
+absent_obs += [
+    top_n_column(n) for n in DEFAULT_TOP_N_VARS if n not in par["top_n_vars"]
+]
+
+absent_var = []
+if par["output_var_obs_mean"] != DEFAULT_VAR_OBS_MEAN:
+    absent_var.append(DEFAULT_VAR_OBS_MEAN)
+    if log1p:
+        absent_var.append(f"log1p_{DEFAULT_VAR_OBS_MEAN}")
+if par["output_var_total_counts_obs"] != DEFAULT_VAR_TOTAL_COUNTS:
+    absent_var.append(DEFAULT_VAR_TOTAL_COUNTS)
+    if log1p:
+        absent_var.append(f"log1p_{DEFAULT_VAR_TOTAL_COUNTS}")
+if par["output_var_num_nonzero_obs"] != DEFAULT_VAR_NUM_NONZERO:
+    absent_var.append(DEFAULT_VAR_NUM_NONZERO)
+if par["output_var_pct_dropout"] != DEFAULT_VAR_PCT_DROPOUT:
+    absent_var.append(DEFAULT_VAR_PCT_DROPOUT)
+
+expected = {
+    "rna": {"obs": rna_obs_present, "var": common_var_present},
+    "prot": {"obs": common_obs_present, "var": common_var_present},
+}
+
+for modality, present in expected.items():
+    mod_obs = list(output.mod[modality].obs)
+    mod_var = list(output.mod[modality].var)
+
+    missing_obs = [k for k in present["obs"] if k not in mod_obs]
+    missing_var = [k for k in present["var"] if k not in mod_var]
+    assert not missing_obs, (
+        f"Missing QC metric obs columns for {modality}: {missing_obs}. Found: {mod_obs}."
+    )
+    assert not missing_var, (
+        f"Missing QC metric var columns for {modality}: {missing_var}. Found: {mod_var}."
+    )
+
+    # When non-default slots are used, the default-named columns must be absent.
+    unexpected_obs = [k for k in absent_obs if k in mod_obs]
+    unexpected_var = [k for k in absent_var if k in mod_var]
+    assert not unexpected_obs, (
+        f"Default-named obs columns should be absent for {modality} when slots are "
+        f"renamed, but found: {unexpected_obs}."
+    )
+    assert not unexpected_var, (
+        f"Default-named var columns should be absent for {modality} when slots are "
+        f"renamed, but found: {unexpected_var}."
+    )
+
+print("Test successful!", flush=True)


### PR DESCRIPTION
## Changelog

### 📚 Stacked PR (1 of 3) — review/merge bottom-up

- 👉 **#1199 — add qc metric calculation** _(this PR)_ — base: `main`
- #1198 — Surface scrublet params — base: `qc-metrics-process-singlesample`
- #1200 — Add quantile filtering — base: `extend-scrublet-params`

Each PR is based on the one **above** it in this list. This is the base of the stack.
**Merge order: #1199 → #1198 → #1200.** Branches are kept in sync with `git rebase` + force-push, so expect the downstream PRs to update after this one merges.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!