### PR TITLE
Fix missing 'httpuv' when installing Seurat

### DIFF
--- a/src/convert/from_h5ad_to_seurat/config.vsh.yaml
+++ b/src/convert/from_h5ad_to_seurat/config.vsh.yaml
@@ -39,14 +39,14 @@ test_resources:
   - path: /resources_test/pbmc_1k_protein_v3/pbmc_1k_protein_v3_filtered_feature_bc_matrix_rna.h5ad
 engines:
   - type: docker
-    image: rocker/r2u:24.04
+    image: rocker/r2u:26.04
     setup:
       - type: apt
         packages: 
           - libhdf5-dev
           - libgeos-dev
       - type: r
-        cran: [ hdf5r, Seurat, SeuratObject ]
+        cran: [ hdf5r, Seurat, SeuratObject, httpuv ]
         bioc: [ anndataR, rhdf5 ]
     test_setup:
       - type: r

--- a/src/convert/from_h5mu_or_h5ad_to_seurat/config.vsh.yaml
+++ b/src/convert/from_h5mu_or_h5ad_to_seurat/config.vsh.yaml
@@ -49,7 +49,7 @@ engines:
       - type: apt
         packages: [ libhdf5-dev, libgeos-dev, hdf5-tools ]
       - type: r
-        cran: [ anndata, hdf5r, Seurat, SeuratObject ]
+        cran: [ anndata, hdf5r, Seurat, SeuratObject, httpuv ]
         bioc: [ anndataR, rhdf5 ]
     test_setup:
       - type: r

--- a/src/convert/from_h5mu_to_seurat/config.vsh.yaml
+++ b/src/convert/from_h5mu_to_seurat/config.vsh.yaml
@@ -45,7 +45,7 @@ engines:
           - libhdf5-dev
           - libgeos-dev
       - type: r
-        cran: [ anndata, hdf5r, testthat, SeuratObject, Seurat ]
+        cran: [ anndata, hdf5r, testthat, SeuratObject, Seurat, httpuv ]
       # Until viash r requirements supports passing secrets
       # --mount only applies to ONE single docker RUN instruction  
       # - type: r


### PR DESCRIPTION
## Changelog

Fix missing `httpuv` when installing Seurat

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- ~[ ] Proposed changes are described in the CHANGELOG.md~

- [x] CI tests succeed!