### PR TITLE
Fix process_batches test_wf2: drop pct_dropout from output prot var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 * `workflows/prot/prot_multisample`: fix two malformed state keys in the `prot_qc` call so the `--output_var_num_nonzero_obs` and `--output_var_pct_dropout` arguments are passed through correctly (PR #1196).
 
+* `workflows/test_workflows/multiomics/process_batches`: drop the recomputed `pct_dropout` column from the prot output in `workflow_test2` before comparing against the reference data, which predates PR #1196 and lacks the column (PR #1209).
+
 # openpipelines 4.1.0
 
 ## NEW FEATURES

--- a/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
+++ b/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
@@ -43,9 +43,7 @@ del output_prot.obs["log1p_num_nonzero_vars"]
 del output_prot.obs["log1p_total_counts"]
 del output_prot.var["log1p_obs_mean"]
 del output_prot.var["log1p_total_counts"]
-# The prot QC metric pct_dropout is now computed by prot_multisample. The reference
-# input predates this, as it was generated when prot_multisample failed to forward
-# the pct_dropout argument to the qc workflow, so it lacks this column.
+# Added after #1196
 del output_prot.var["pct_dropout"]
 assert_annotation_objects_equal(input_prot, output_prot, promote_precision=True)
 

--- a/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
+++ b/src/workflows/test_workflows/multiomics/process_batches/workflow_test2/script.py
@@ -43,6 +43,10 @@ del output_prot.obs["log1p_num_nonzero_vars"]
 del output_prot.obs["log1p_total_counts"]
 del output_prot.var["log1p_obs_mean"]
 del output_prot.var["log1p_total_counts"]
+# The prot QC metric pct_dropout is now computed by prot_multisample. The reference
+# input predates this, as it was generated when prot_multisample failed to forward
+# the pct_dropout argument to the qc workflow, so it lacks this column.
+del output_prot.var["pct_dropout"]
 assert_annotation_objects_equal(input_prot, output_prot, promote_precision=True)
 
 


### PR DESCRIPTION
## Changelog

Fixes the `process_batches` `workflow_test2` integration test, which broke after PR #1196. Now that `prot_multisample` correctly writes the `pct_dropout` QC metric to the prot `.var`, the test drops that column from the output before comparing against the reference data (which predates #1196 and lacks it), matching the existing log1p handling.

## Issue ticket number and link
~Closes #xxxx~ — no issue; surfaced via failing CI.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!
