### PR TITLE
Make `transform/scale` `--zero_center` a regular boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## BREAKING CHANGES
 
-* `transform/scale`: `--zero_center` is now a regular `boolean` (default `true`) instead of a `boolean_false` flag. Pass `--zero_center false` to omit centering (PR #1216).
+* `transform/scale`: `--zero_center` is now a regular `boolean` (default behaviour remains unaltered and is set explicitly to `true`) instead of a `boolean_false` flag. Pass `--zero_center false` to omit centering (PR #1216).
 
-* `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: the RNA scaling zero-center argument is now a regular `boolean` (default `true`) instead of `boolean_false` (PR #1216).
+* `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: the RNA scaling zero-center argument is now a regular `boolean` (default behaviour remains unaltered and is set explicitly to `true`) instead of `boolean_false` (PR #1216).
 
 # openpipelines 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# openpipelines x.x.x
+
+## BREAKING CHANGES
+
+* `transform/scale`: `--zero_center` is now a regular `boolean` (default `true`) instead of a `boolean_false` flag. Pass `--zero_center false` to omit centering (PR #XXXX).
+
+* `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: the RNA scaling zero-center argument is now a regular `boolean` (default `true`) instead of `boolean_false` (PR #XXXX).
+
 # openpipelines 4.2.0
 
 ## NEW FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## BREAKING CHANGES
 
-* `transform/scale`: `--zero_center` is now a regular `boolean` (default `true`) instead of a `boolean_false` flag. Pass `--zero_center false` to omit centering (PR #XXXX).
+* `transform/scale`: `--zero_center` is now a regular `boolean` (default `true`) instead of a `boolean_false` flag. Pass `--zero_center false` to omit centering (PR #1216).
 
-* `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: the RNA scaling zero-center argument is now a regular `boolean` (default `true`) instead of `boolean_false` (PR #XXXX).
+* `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`: the RNA scaling zero-center argument is now a regular `boolean` (default `true`) instead of `boolean_false` (PR #1216).
 
 # openpipelines 4.2.0
 

--- a/src/transform/scale/config.vsh.yaml
+++ b/src/transform/scale/config.vsh.yaml
@@ -32,8 +32,9 @@ arguments:
     type: double
     description: Clip (truncate) to this value after scaling. Does not clip by default.
   - name: "--zero_center"
-    type: boolean_false
-    description: If set, omit zero-centering variables, which allows to handle sparse input efficiently.
+    type: boolean
+    default: true
+    description: If true, center the data to zero mean before scaling. Set to false to omit zero-centering, which allows sparse input to be handled efficiently.
   # output
   - name: "--output"
     alternatives: ["-o"]

--- a/src/workflows/multiomics/process_batches/config.vsh.yaml
+++ b/src/workflows/multiomics/process_batches/config.vsh.yaml
@@ -166,8 +166,9 @@ argument_groups:
         required: false
         type: double
       - name: "--rna_scaling_zero_center"
-        type: boolean_false
-        description: If set, omit zero-centering variables, which allows to handle sparse input efficiently."
+        type: boolean
+        default: true
+        description: If true, center the data to zero mean before scaling. Set to false to omit zero-centering, which allows sparse input to be handled efficiently.
          
 dependencies:
   - name: dataflow/merge

--- a/src/workflows/multiomics/process_samples/config.vsh.yaml
+++ b/src/workflows/multiomics/process_samples/config.vsh.yaml
@@ -335,8 +335,9 @@ argument_groups:
         required: false
         type: double
       - name: "--rna_scaling_zero_center"
-        type: boolean_false
-        description: If set, omit zero-centering variables, which allows to handle sparse input efficiently."
+        type: boolean
+        default: true
+        description: If true, center the data to zero mean before scaling. Set to false to omit zero-centering, which allows sparse input to be handled efficiently.
           
 dependencies:
   - name: metadata/add_id

--- a/src/workflows/rna/rna_multisample/config.vsh.yaml
+++ b/src/workflows/rna/rna_multisample/config.vsh.yaml
@@ -183,8 +183,9 @@ argument_groups:
         required: false
         type: double
       - name: "--scaling_zero_center"
-        type: boolean_false
-        description: If set, omit zero-centering variables, which allows to handle sparse input efficiently."
+        type: boolean
+        default: true
+        description: If true, center the data to zero mean before scaling. Set to false to omit zero-centering, which allows sparse input to be handled efficiently.
          
 dependencies:
   - name: feature_annotation/highly_variable_features_scanpy


### PR DESCRIPTION
## Why

`transform/scale`'s `--zero_center` is a `boolean_false` flag: despite its name, *providing* the bare flag turns zero-centering **off**, which reads backwards. This makes it a plain `boolean` (default `true`), so `--zero_center true`/`--zero_center false` mean exactly what they say.

## Changes

- `transform/scale`: `--zero_center` `boolean_false` → `boolean` (`default: true`), clearer description.
- Same change to the RNA scaling zero-center argument in `workflows/rna/rna_multisample`, `workflows/multiomics/process_samples`, `workflows/multiomics/process_batches`.

## Impact

Default behavior is unchanged (data is still zero-centered by default). `script.py` already passes the value straight to `scanpy.pp.scale`, and workflows thread the value via state, so no functional change. The only removed behavior is the bare `--zero_center` flag (use `--zero_center false` instead).