### PR TITLE
Replace end-of-life Debian bullseye base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * `feature_annotation/highly_variable_features_scanpy`: always store details of highly variable features, regardless of the flavor used (PR #1186)
 
+* `transform/tfidf`, `report/mermaid`: replace the end-of-life Debian bullseye base images, whose package pool has been purged, causing the Docker image builds to fail. `report/mermaid` also moves off Node 20, which is end-of-life (PR #1230).
+
 # openpipelines 4.2.0
 
 ## NEW FEATURES

--- a/src/report/mermaid/config.vsh.yaml
+++ b/src/report/mermaid/config.vsh.yaml
@@ -52,7 +52,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: "node:20-bullseye"
+    image: "node:20-bookworm"
     setup:
       - type: javascript
         npm: 

--- a/src/report/mermaid/config.vsh.yaml
+++ b/src/report/mermaid/config.vsh.yaml
@@ -52,7 +52,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: "node:20-bookworm"
+    image: "node:22-bookworm"
     setup:
       - type: javascript
         npm: 

--- a/src/transform/tfidf/config.vsh.yaml
+++ b/src/transform/tfidf/config.vsh.yaml
@@ -83,7 +83,7 @@ test_resources:
   - path: /resources_test/cellranger_atac_tiny_bcl/counts/
 engines:
   - type: docker
-    image: python:3.13-slim-bullseye
+    image: python:3.13-slim
     setup:
       - type: apt
         packages: 


### PR DESCRIPTION
## Changelog

Debian 11 (bullseye) reached end-of-life on 2026-08-31 and its package pool has been purged while the index still lists the packages, so `apt-get install` fails with 404s. This breaks the Docker image builds for these two components in the nightly `integration test`.

- `transform/tfidf`: `python:3.13-slim-bullseye` -> `python:3.13-slim`
- `report/mermaid`: `node:20-bullseye` -> `node:22-bookworm` (Node 20 is end-of-life as well)

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!
