### PR TITLE
Match the `muon` sparse geometric mean in `transform/clr` tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * `feature_annotation/highly_variable_features_scanpy`: always store details of highly variable features, regardless of the flavor used (PR #1186)
 
-* `transform/clr`: compute the expected values in the unit tests in float64 and compare them with a tolerance appropriate for float32, instead of relying on the output being bit-for-bit identical to a numpy reimplementation of `muon` internals (PR #1231).
+* `transform/clr`: compute the expected geometric mean in the unit tests over the sparse matrix, matching how `muon` calculates it since 0.1.8, instead of over a densified column (PR #1231).
 
 # openpipelines 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * `feature_annotation/highly_variable_features_scanpy`: always store details of highly variable features, regardless of the flavor used (PR #1186)
 
+* `transform/clr`: compute the expected values in the unit tests in float64 and compare them with a tolerance appropriate for float32, instead of relying on the output being bit-for-bit identical to a numpy reimplementation of `muon` internals (PR #1231).
+
 # openpipelines 4.2.0
 
 ## NEW FEATURES

--- a/src/transform/clr/test.py
+++ b/src/transform/clr/test.py
@@ -39,14 +39,16 @@ def test_clr(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    input_col = input.mod["prot"].X[:, 0].toarray().astype(np.float64)
+    # CLR normalizes across the requested axis, which requires CSC for axis 0.
+    # The geometric mean is taken over the sparse matrix rather than a dense
+    # column, because summing only the stored values is what determines the
+    # float32 rounding of the result.
+    input_x = input.mod["prot"].X.tocsc()
+    input_col = input_x[:, 0].toarray()
     result_col = output_h5mu.mod["prot"].layers["clr"][:, 0].toarray()
-    expected_col = np.log1p(
-        input_col / np.exp(np.log1p(input_col).sum(axis=0) / input_col.size)
-    )
-    # The reference is computed in float64 while the component works in float32,
-    # so the comparison must tolerate float32 error accumulated by the sum.
-    np.testing.assert_allclose(result_col, expected_col, rtol=1e-5)
+    logmean = np.asarray(np.log1p(input_x).mean(axis=0)).ravel()[0]
+    expected_col = np.log1p(input_col / np.exp(logmean))
+    np.testing.assert_allclose(result_col, expected_col)
 
 
 def test_clr_not_enough_observation_raises(run_component, tmp_path):
@@ -162,14 +164,13 @@ def test_clr_set_axis(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    input_row = input.mod["prot"].X[0].toarray().astype(np.float64)
+    # Normalizing across axis 1 requires CSR, see the note in test_clr.
+    input_x = input.mod["prot"].X.tocsr()
+    input_row = input_x[0].toarray()
     result_row = output_h5mu.mod["prot"].layers["clr"][0].toarray()
-    expected_row = np.log1p(
-        input_row / np.exp(np.log1p(input_row).sum(axis=1) / input_row.size)
-    )
-    # The reference is computed in float64 while the component works in float32,
-    # so the comparison must tolerate float32 error accumulated by the sum.
-    np.testing.assert_allclose(result_row, expected_row, rtol=1e-5)
+    logmean = np.asarray(np.log1p(input_x).mean(axis=1)).ravel()[0]
+    expected_row = np.log1p(input_row / np.exp(logmean))
+    np.testing.assert_allclose(result_row, expected_row)
 
 
 if __name__ == "__main__":

--- a/src/transform/clr/test.py
+++ b/src/transform/clr/test.py
@@ -39,12 +39,14 @@ def test_clr(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    input_col = input.mod["prot"].X[:, 0].toarray()
+    input_col = input.mod["prot"].X[:, 0].toarray().astype(np.float64)
     result_col = output_h5mu.mod["prot"].layers["clr"][:, 0].toarray()
     expected_col = np.log1p(
         input_col / np.exp(np.log1p(input_col).sum(axis=0) / input_col.size)
     )
-    np.testing.assert_allclose(result_col, expected_col)
+    # The reference is computed in float64 while the component works in float32,
+    # so the comparison must tolerate float32 error accumulated by the sum.
+    np.testing.assert_allclose(result_col, expected_col, rtol=1e-5)
 
 
 def test_clr_not_enough_observation_raises(run_component, tmp_path):
@@ -160,12 +162,14 @@ def test_clr_set_axis(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    input_row = input.mod["prot"].X[0].toarray()
+    input_row = input.mod["prot"].X[0].toarray().astype(np.float64)
     result_row = output_h5mu.mod["prot"].layers["clr"][0].toarray()
     expected_row = np.log1p(
         input_row / np.exp(np.log1p(input_row).sum(axis=1) / input_row.size)
     )
-    np.testing.assert_allclose(result_row, expected_row)
+    # The reference is computed in float64 while the component works in float32,
+    # so the comparison must tolerate float32 error accumulated by the sum.
+    np.testing.assert_allclose(result_row, expected_row, rtol=1e-5)
 
 
 if __name__ == "__main__":

--- a/src/transform/clr/test.py
+++ b/src/transform/clr/test.py
@@ -39,10 +39,7 @@ def test_clr(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    # CLR normalizes across the requested axis, which requires CSC for axis 0.
-    # The geometric mean is taken over the sparse matrix rather than a dense
-    # column, because summing only the stored values is what determines the
-    # float32 rounding of the result.
+    # Match muon: take the mean over the sparse matrix, CSC for axis 0.
     input_x = input.mod["prot"].X.tocsc()
     input_col = input_x[:, 0].toarray()
     result_col = output_h5mu.mod["prot"].layers["clr"][:, 0].toarray()
@@ -164,7 +161,7 @@ def test_clr_set_axis(run_component, tmp_path):
     assert "clr" in output_h5mu.mod["prot"].layers.keys()
     assert output_h5mu.mod["prot"].layers["clr"] is not None
     input = read_h5mu(input_file)
-    # Normalizing across axis 1 requires CSR, see the note in test_clr.
+    # Match muon: take the mean over the sparse matrix, CSR for axis 1.
     input_x = input.mod["prot"].X.tocsr()
     input_row = input_x[0].toarray()
     result_row = output_h5mu.mod["prot"].layers["clr"][0].toarray()


### PR DESCRIPTION
## Changelog

`viash test` fails for `transform/clr` because the unit tests reproduce the geometric mean differently from `muon`.

`muon~=0.1.7` means `>=0.1.7,<0.2.0` and the engine image is built without a lockfile, so a rebuild moved the installed version from 0.1.7 to 0.1.9. muon 0.1.8 reworked `prot.pp.clr` to take the mean over the sparse matrix, while the tests computed their reference over a densified column. That is the same value mathematically, but scipy's sparse `.mean()` sums only the stored non-zeros where a dense reduction sums every element pairwise, so the two round differently in float32 (~4e-6).

The tests now take the mean over the sparse matrix as `muon` does, in the layout it requires (CSC for `axis=0`, CSR for `axis=1`). This reproduces the component output bit-for-bit, so the tolerance is unchanged.

#1232 tightens the pin to `muon~=0.1.9`, so a future release cannot change this silently again.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!
