### PR TITLE
Pin `muon` to `~=0.1.9` and set the CLR flavor explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 * `filter/create_cell_masks`: added a component to create boolean cell masks from a set of user-provided filters (PR #1165).
 
+## MINOR CHANGES
+
+* `transform/clr`, `transform/tfidf`, `dimred/lsi`, `qc/calculate_atac_qc_metrics`: pin `muon` to `~=0.1.9`, since `0.1.8` reimplemented several of the functions used by these components (PR #1232).
+
+* `transform/clr`: pass `flavor="seurat"` to `muon` explicitly, so that a change to the `muon` default cannot silently alter the normalized counts (PR #1232).
+
 ## BUG FIXES
 
 * `feature_annotation/highly_variable_features_scanpy`: always store details of highly variable features, regardless of the flavor used (PR #1186)

--- a/src/dimred/lsi/config.vsh.yaml
+++ b/src/dimred/lsi/config.vsh.yaml
@@ -108,7 +108,7 @@ engines:
       - type: python
         __merge__: [../../../src/base/requirements/anndata_mudata.yaml, .]
         packages:
-          - muon~=0.1.7
+          - muon~=0.1.9
     __merge__: [ /src/base/requirements/python_test_setup.yaml, .]
 runners:
   - type: executable

--- a/src/qc/calculate_atac_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_atac_qc_metrics/config.vsh.yaml
@@ -106,7 +106,7 @@ engines:
         __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
         __merge__: [ /src/base/requirements/scanpy.yaml, .]
         packages:
-          - muon~=0.1.7
+          - muon~=0.1.9
           - pysam~=0.22.0
     test_setup:
       - type: python

--- a/src/transform/clr/config.vsh.yaml
+++ b/src/transform/clr/config.vsh.yaml
@@ -63,7 +63,7 @@ engines:
     - type: python
       __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/scanpy.yaml, .]
       packages:
-        - muon~=0.1.7
+        - muon~=0.1.9
   test_setup:
     - type: python
       __merge__: [ /src/base/requirements/viashpy.yaml, .]

--- a/src/transform/clr/script.py
+++ b/src/transform/clr/script.py
@@ -29,7 +29,11 @@ def main():
     )
     # CLR always normalizes the .X layer, so we have to create an AnnData file with
     # the input layer at .X
-    normalized_counts = pt.pp.clr(input_data, axis=par["axis"], inplace=False)
+    # The flavor is set explicitly so that a change to the muon default does not
+    # silently alter the normalized counts.
+    normalized_counts = pt.pp.clr(
+        input_data, axis=par["axis"], inplace=False, flavor="seurat"
+    )
     if not normalized_counts:
         raise RuntimeError("CLR failed to return the requested output layer")
 

--- a/src/transform/tfidf/config.vsh.yaml
+++ b/src/transform/tfidf/config.vsh.yaml
@@ -94,7 +94,7 @@ engines:
       - type: python
         __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/scanpy.yaml, .]
         packages:
-          - muon~=0.1.7
+          - muon~=0.1.9
     test_setup:
       - type: python
         __merge__: [ /src/base/requirements/viashpy.yaml, .]


### PR DESCRIPTION
## Changelog

`muon~=0.1.7` resolves to `>=0.1.7,<0.2.0`, which allowed muon 0.1.8 to reimplement `prot.pp.clr` under an apparently compatible release (see #1231). muon is still 0.x, so minor bumps can carry breaking changes.

- Pin `muon~=0.1.9` in `transform/clr`, `transform/tfidf`, `dimred/lsi` and `qc/calculate_atac_qc_metrics`.
- `transform/clr`: pass `flavor="seurat"` explicitly rather than relying on the muon default. The argument was added in 0.1.8, so the pin is a prerequisite.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!
