### PR TITLE
Fix duplicate `__merge__` in `calculate_atac_qc_metrics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * `feature_annotation/highly_variable_features_scanpy`: always store details of highly variable features, regardless of the flavor used (PR #1186)
 
+* `qc/calculate_atac_qc_metrics`: merge the `anndata`/`mudata` and `scanpy` requirements into a single `__merge__` field. Two `__merge__` fields were specified for the same Python setup, of which only the last one was applied, leaving `anndata` and `mudata` unpinned (PR #1233).
+
 # openpipelines 4.2.0
 
 ## NEW FEATURES

--- a/src/qc/calculate_atac_qc_metrics/config.vsh.yaml
+++ b/src/qc/calculate_atac_qc_metrics/config.vsh.yaml
@@ -103,8 +103,7 @@ engines:
           - libhdf5-dev
           - gcc
       - type: python
-        __merge__: [/src/base/requirements/anndata_mudata.yaml, .]
-        __merge__: [ /src/base/requirements/scanpy.yaml, .]
+        __merge__: [/src/base/requirements/anndata_mudata.yaml, /src/base/requirements/scanpy.yaml, .]
         packages:
           - muon~=0.1.7
           - pysam~=0.22.0


### PR DESCRIPTION
## Changelog

`qc/calculate_atac_qc_metrics` specified two `__merge__` fields for the same Python setup. Duplicate keys in a YAML mapping mean only the last one applies, so the `anndata`/`mudata` requirements were silently dropped and both ended up unpinned (`scanpy` and `muon` pull them in transitively).

Merging the two lists into a single `__merge__` restores the intended pins.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Conforms to the [Contributor's guide](https://openpipelines.bio/contributing)

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Documentation
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] CI tests succeed!
